### PR TITLE
CDMS 216 Connect to IBM T2 using IP

### DIFF
--- a/BtmsGateway.Test/Middleware/MessageDataTests.cs
+++ b/BtmsGateway.Test/Middleware/MessageDataTests.cs
@@ -1,0 +1,333 @@
+using System.Net;
+using BtmsGateway.Middleware;
+using BtmsGateway.Services.Routing;
+using BtmsGateway.Test.TestUtils;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Serilog.Core;
+
+namespace BtmsGateway.Test.Middleware;
+
+public class MessageDataTests
+{
+    private readonly DefaultHttpContext _httpContext = new()
+    {
+        Request =
+        {
+            Method = "GET",
+            Protocol = "http",
+            Host = new HostString("localhost", 123),
+            Headers =
+            {
+                new KeyValuePair<string, StringValues>("Content-Length", "999"),
+                new KeyValuePair<string, StringValues>("X-Correlation-ID", "correlation-id"),
+                new KeyValuePair<string, StringValues>("X-Custom", "custom")
+            }
+        }
+    };
+    
+    [Theory]
+    [InlineData("/")]
+    [InlineData("/cds")]
+    [InlineData("/alvs-cds")]
+    [InlineData("/alvs-ipaffs")]
+    [InlineData("/test")]
+    [InlineData("/simulator/cds")]
+    [InlineData("/simulator/alvs-cds")]
+    [InlineData("/simulator/alvs-ipaffs")]
+    [InlineData("/anything")]
+    public async Task When_receiving_a_get_request_that_should_be_processed_Then_it_should_indicate_so(string path)
+    {
+        _httpContext.Request.Path = new PathString(path);
+        
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+
+        messageData.ShouldProcessRequest.Should().BeTrue();
+    }
+    
+    [Theory]
+    [InlineData("/health")]
+    [InlineData("/swagger")]
+    public async Task When_receiving_a_post_request_that_should_be_processed_Then_it_should_indicate_so(string path)
+    {
+        _httpContext.Request.Method = "POST";
+        _httpContext.Request.Path = new PathString(path);
+        
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+
+        messageData.ShouldProcessRequest.Should().BeTrue();
+    }
+    
+    [Theory]
+    [InlineData("/health")]
+    [InlineData("/swagger")]
+    [InlineData("/checkroutes/")]
+    [InlineData("/checkroutes/json")]
+    [InlineData("/checkroutes/ipaffs")]
+    [InlineData("/checkroutes/ipaffs/json")]
+    public async Task When_receiving_a_get_request_that_should_not_be_processed_Then_it_should_indicate_so(string path)
+    {
+        _httpContext.Request.Path = new PathString(path);
+        
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+
+        messageData.ShouldProcessRequest.Should().BeFalse();
+    }
+    
+    [Fact]
+    public async Task When_receiving_a_routable_get_request_without_content_type_or_accept_headers_Then_it_should_break_up_the_request_parts()
+    {
+        _httpContext.Request.Path = new PathString("/cds/path");
+        _httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues> { { "a", "b" } });
+        
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+
+        messageData.HttpString.Should().Be("GET http://localhost:123/cds/path?a=b HTTP/1.1 ");
+        messageData.Method.Should().Be("GET");
+        messageData.Path.Should().Be("cds/path");
+        messageData.Url.Should().Be("http://localhost:123/cds/path?a=b");
+        messageData.CorrelationId.Should().Be("correlation-id");
+        messageData.OriginalContentType.Should().Be("");
+        messageData.OriginalContentAsString.Should().BeNull();
+        messageData.ContentMap.ChedType.Should().BeNull();
+        messageData.ContentMap.CountryCode.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task When_receiving_a_routable_get_request_with_accept_header_Then_it_should_break_up_the_request_parts()
+    {
+        _httpContext.Request.Headers.Add(new KeyValuePair<string, StringValues>("Accept", "application/json"));
+        
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+
+        messageData.OriginalContentType.Should().Be("application/json");
+    }
+
+    [Fact]
+    public async Task When_creating_a_routable_get_request_without_host_header_Then_it_should_create_forwarding_request()
+    {
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+        
+        var request = messageData.CreateForwardingRequestAsOriginal("https://localhost:456/cds/path", null);
+
+        request.RequestUri!.ToString().Should().Be("https://localhost:456/cds/path");
+        request.Method.Should().Be(HttpMethod.Get);
+        request.Version.Should().Be(Version.Parse("1.1"));
+        request.Content.Should().BeNull();
+        request.Headers.Count().Should().Be(2);
+        request.Headers.GetValues(MessageData.CorrelationIdHeaderName).Should().BeEquivalentTo("correlation-id");
+        request.Headers.GetValues("X-Custom").Should().BeEquivalentTo("custom");
+    }
+    
+    [Fact]
+    public async Task When_creating_a_routable_get_request_with_host_header_Then_it_should_create_forwarding_request()
+    {
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+        
+        var request = messageData.CreateForwardingRequestAsOriginal("https://localhost:456/cds/path", "host-header");
+
+        request.Headers.Count().Should().Be(3);
+        request.Headers.GetValues("host").Should().BeEquivalentTo("host-header");
+    }
+
+    [Fact]
+    public async Task When_creating_a_routable_get_request_with_content_Then_it_should_create_forwarding_request()
+    {
+        _httpContext.Request.Headers.ContentType = "application/soap+xml";
+        _httpContext.Request.Body = new MemoryStream("<root><data>abc</data></root>"u8.ToArray());
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+        
+        var request = messageData.CreateForwardingRequestAsOriginal("https://localhost:456/cds/path", null);
+
+        request.Content.Should().BeNull();
+        request.Headers.Count().Should().Be(3);
+        request.Headers.GetValues(MessageData.CorrelationIdHeaderName).Should().BeEquivalentTo("correlation-id");
+        request.Headers.GetValues("X-Custom").Should().BeEquivalentTo("custom");
+        request.Headers.GetValues("Accept").Should().BeEquivalentTo("application/soap+xml");
+    }
+    
+    [Fact]
+    public async Task When_creating_a_routable_get_request_with_accept_header_Then_it_should_create_forwarding_request()
+    {
+        _httpContext.Request.Headers.Add(new KeyValuePair<string, StringValues>("Accept", "application/json"));
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+        
+        var request = messageData.CreateForwardingRequestAsOriginal("https://localhost:456/cds/path", null);
+
+        request.Headers.Count().Should().Be(3);
+        request.Headers.GetValues(MessageData.CorrelationIdHeaderName).Should().BeEquivalentTo("correlation-id");
+        request.Headers.GetValues("X-Custom").Should().BeEquivalentTo("custom");
+        request.Headers.GetValues("Accept").Should().BeEquivalentTo("application/json");
+    }
+
+    [Fact]
+    public async Task When_receiving_an_original_routable_post_request_Then_it_should_break_up_the_request_parts()
+    {
+        _httpContext.Request.Method = "POST";
+        _httpContext.Request.Path = new PathString("/cds/path");
+        _httpContext.Request.Headers.ContentType = "application/soap+xml";
+        _httpContext.Request.Body = new MemoryStream("<root><data>abc</data></root>"u8.ToArray());
+        
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+
+        messageData.HttpString.Should().Be("POST http://localhost:123/cds/path HTTP/1.1 application/soap+xml");
+        messageData.Method.Should().Be("POST");
+        messageData.Path.Should().Be("cds/path");
+        messageData.Url.Should().Be("http://localhost:123/cds/path");
+        messageData.CorrelationId.Should().Be("correlation-id");
+        messageData.OriginalContentType.Should().Be("application/soap+xml");
+        messageData.OriginalContentAsString.Should().Be("<root><data>abc</data></root>");
+        messageData.ContentMap.ChedType.Should().Be("");
+        messageData.ContentMap.CountryCode.Should().Be("");
+    }
+    
+    [Fact]
+    public async Task When_receiving_an_original_routable_post_request_with_mappable_content_Then_it_should_break_up_the_request_parts()
+    {
+        _httpContext.Request.Method = "POST";
+        _httpContext.Request.Path = new PathString("/cds/path");
+        _httpContext.Request.Headers.ContentType = "application/soap+xml";
+        _httpContext.Request.Body = new MemoryStream("<root><ched>CHEDPP</ched><DispatchCountryCode>NI</DispatchCountryCode></root>"u8.ToArray());
+        
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+
+        messageData.OriginalContentAsString.Should().Be("<root><ched>CHEDPP</ched><DispatchCountryCode>NI</DispatchCountryCode></root>");
+        messageData.ContentMap.ChedType.Should().Be("CHEDPP");
+        messageData.ContentMap.CountryCode.Should().Be("NI");
+    }
+
+    [Fact]
+    public async Task When_creating_a_routable_original_post_request_with_host_header_Then_it_should_create_forwarding_request()
+    {
+        _httpContext.Request.Method = "POST";
+        _httpContext.Request.Path = new PathString("/cds/path");
+        _httpContext.Request.Headers.ContentType = "application/soap+xml";
+        _httpContext.Request.Body = new MemoryStream("<root><data>abc</data></root>"u8.ToArray());
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+        
+        var request = messageData.CreateForwardingRequestAsOriginal("https://localhost:456/cds/path", "host-header");
+
+        request.RequestUri!.ToString().Should().Be("https://localhost:456/cds/path");
+        request.Method.Should().Be(HttpMethod.Post);
+        request.Version.Should().Be(Version.Parse("1.1"));
+        (await request.Content!.ReadAsStringAsync()).Should().Be("<root><data>abc</data></root>");
+        request.Content!.Headers.ContentType!.ToString().Should().Be("application/soap+xml; charset=utf-8");
+        request.Headers.Count().Should().Be(4);
+        request.Headers.GetValues(MessageData.CorrelationIdHeaderName).Should().BeEquivalentTo("correlation-id");
+        request.Headers.GetValues("X-Custom").Should().BeEquivalentTo("custom");
+        request.Headers.GetValues("Accept").Should().BeEquivalentTo("application/soap+xml");
+        request.Headers.GetValues("host").Should().BeEquivalentTo("host-header");
+    }
+
+    [Fact]
+    public async Task When_creating_a_routable_converted_post_request_Then_it_should_create_forwarding_request()
+    {
+        _httpContext.Request.Method = "POST";
+        _httpContext.Request.Path = new PathString("/cds/path");
+        _httpContext.Request.Headers.ContentType = "application/soap+xml";
+        _httpContext.Request.Body = new MemoryStream("<root><data>abc</data></root>"u8.ToArray());
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+        
+        var request = messageData.CreateForwardingRequestAsJson("https://localhost:456/cds/path", null);
+
+        (await request.Content!.ReadAsStringAsync()).LinuxLineEndings().Should().Be("{\n  \"root\": {\n    \"data\": \"abc\"\n  }\n}");
+        request.Content!.Headers.ContentType!.ToString().Should().Be("application/json; charset=utf-8");
+        request.Headers.Count().Should().Be(3);
+        request.Headers.GetValues("Accept").Should().BeEquivalentTo("application/json");
+    }
+
+    [Fact]
+    public async Task When_populating_a_response_with_content_and_existing_date_Then_it_should_populate_response()
+    {
+        var responseDate = DateTimeOffset.Now;
+        _httpContext.Request.Method = "POST";
+        _httpContext.Request.Path = new PathString("/cds/path");
+        _httpContext.Request.Headers.ContentType = "application/soap+xml";
+        _httpContext.Request.Body = new MemoryStream("<root><data>abc</data></root>"u8.ToArray());
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+        var responseBody = new MemoryStream();
+        _httpContext.Response.Body = responseBody;
+
+        await messageData.PopulateResponse(_httpContext.Response, new RoutingResult { StatusCode = HttpStatusCode.OK, UrlPath = "cds/path", ResponseDate = responseDate, ResponseContent = "response-content" });
+
+        _httpContext.Response.StatusCode.Should().Be(200);
+        _httpContext.Response.Headers.Date[0].Should().Be(responseDate.ToString("R"));
+        _httpContext.Response.Headers[MessageData.CorrelationIdHeaderName][0].Should().Be("correlation-id");
+        _httpContext.Response.Headers[MessageData.RequestedPathHeaderName][0].Should().Be("cds/path");
+        _httpContext.Response.ContentType.Should().Be("application/soap+xml");
+        responseBody.Position = 0;
+        var body = await new StreamReader(responseBody).ReadToEndAsync();
+        body.Should().Be("response-content");
+    }
+
+    [Fact]
+    public async Task When_populating_a_response_with_no_date_Then_it_should_populate_response()
+    {
+        _httpContext.Request.Method = "POST";
+        _httpContext.Request.Path = new PathString("/cds/path");
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+
+        await messageData.PopulateResponse(_httpContext.Response, new RoutingResult { StatusCode = HttpStatusCode.OK, UrlPath = "cds/path" });
+
+        _httpContext.Response.StatusCode.Should().Be(200);
+        _httpContext.Response.Headers.Date[0].Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task When_populating_a_response_with_no_content_Then_it_should_populate_response()
+    {
+        _httpContext.Request.Method = "POST";
+        _httpContext.Request.Path = new PathString("/cds/path");
+        _httpContext.Request.Headers.ContentType = "application/soap+xml";
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+        var responseBody = new MemoryStream();
+        _httpContext.Response.Body = responseBody;
+
+        await messageData.PopulateResponse(_httpContext.Response, new RoutingResult { StatusCode = HttpStatusCode.OK, UrlPath = "cds/path" });
+
+        _httpContext.Response.StatusCode.Should().Be(200);
+        _httpContext.Response.ContentType.Should().Be("application/soap+xml");
+        responseBody.Position = 0;
+        var body = await new StreamReader(responseBody).ReadToEndAsync();
+        body.Should().Be("");
+    }
+
+    [Fact]
+    public async Task When_populating_a_response_with_no_content_or_content_type_Then_it_should_populate_response()
+    {
+        _httpContext.Request.Method = "POST";
+        _httpContext.Request.Path = new PathString("/cds/path");
+        _httpContext.Request.Headers.ContentType = [];
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+        var responseBody = new MemoryStream();
+        _httpContext.Response.Body = responseBody;
+
+        await messageData.PopulateResponse(_httpContext.Response, new RoutingResult { StatusCode = HttpStatusCode.OK, UrlPath = "cds/path" });
+
+        _httpContext.Response.StatusCode.Should().Be(200);
+        _httpContext.Response.ContentType.Should().BeNull();
+        responseBody.Position = 0;
+        var body = await new StreamReader(responseBody).ReadToEndAsync();
+        body.Should().Be("");
+    }
+
+    [Fact]
+    public async Task When_populating_a_no_content_response_with_no_content_Then_it_should_populate_response()
+    {
+        _httpContext.Request.Method = "POST";
+        _httpContext.Request.Path = new PathString("/cds/path");
+        _httpContext.Request.Headers.ContentType = [];
+        var messageData = await MessageData.Create(_httpContext.Request, Logger.None);
+        var responseBody = new MemoryStream();
+        _httpContext.Response.Body = responseBody;
+
+        await messageData.PopulateResponse(_httpContext.Response, new RoutingResult { StatusCode = HttpStatusCode.NoContent, UrlPath = "cds/path" });
+
+        _httpContext.Response.StatusCode.Should().Be(204);
+        _httpContext.Response.ContentType.Should().BeNull();
+        responseBody.Position = 0;
+        var body = await new StreamReader(responseBody).ReadToEndAsync();
+        body.Should().Be("");
+    }
+}

--- a/BtmsGateway.Test/Services/Routing/MessageRoutesTests.cs
+++ b/BtmsGateway.Test/Services/Routing/MessageRoutesTests.cs
@@ -17,8 +17,10 @@ public class MessageRoutesTests
         route.RouteFound.Should().BeTrue();
         route.RouteName.Should().Be("route-1");
         route.FullRouteLink.Should().Be("http://legacy-link-url/sub/path");
+        route.RouteHostHeader.Should().Be("legacy-host-header");
         route.ConvertedRoutedContentToJson.Should().BeFalse();
         route.FullForkLink.Should().Be("btms-link-queue");
+        route.ForkHostHeader.Should().BeNull();
         route.ConvertedForkedContentToJson.Should().BeTrue();
         route.UrlPath.Should().Be("/sub/path");
     }
@@ -33,8 +35,10 @@ public class MessageRoutesTests
         route.RouteFound.Should().BeTrue();
         route.RouteName.Should().Be("route-2");
         route.FullRouteLink.Should().Be("http://btms-link-url/sub/path");
+        route.RouteHostHeader.Should().Be("btms-host-header");
         route.ConvertedRoutedContentToJson.Should().BeTrue();
         route.FullForkLink.Should().Be("legacy-link-queue");
+        route.ForkHostHeader.Should().BeNull();
         route.ConvertedForkedContentToJson.Should().BeFalse();
         route.UrlPath.Should().Be("/sub/path");
     }
@@ -49,7 +53,9 @@ public class MessageRoutesTests
         route.RouteFound.Should().BeFalse();
         route.RouteName.Should().Be("route-3");
         route.FullRouteLink.Should().BeNull();
+        route.RouteHostHeader.Should().BeNull();
         route.FullForkLink.Should().BeNull();
+        route.ForkHostHeader.Should().BeNull();
         route.UrlPath.Should().Be("/sub/path");
     }
 

--- a/BtmsGateway.Test/Services/Routing/RoutingConfigTests.cs
+++ b/BtmsGateway.Test/Services/Routing/RoutingConfigTests.cs
@@ -12,8 +12,10 @@ public class RoutingConfigTests
         route.Name.Should().Be("route-1");
         route.LegacyLink.Should().Be("http://legacy-link-url");
         route.LegacyLinkType.Should().Be(LinkType.Url);
+        route.LegacyHostHeader.Should().Be("legacy-host-header");
         route.BtmsLink.Should().Be("btms-link-queue");
         route.BtmsLinkType.Should().Be(LinkType.Queue);
+        route.BtmsHostHeader.Should().BeNull();
         route.SendLegacyResponseToBtms.Should().BeTrue();
         route.RouteTo.Should().Be(RouteTo.Legacy);
     }
@@ -25,8 +27,10 @@ public class RoutingConfigTests
         route.Name.Should().Be("route-2");
         route.LegacyLink.Should().Be("legacy-link-queue");
         route.LegacyLinkType.Should().Be(LinkType.Queue);
+        route.LegacyHostHeader.Should().BeNull();
         route.BtmsLink.Should().Be("http://btms-link-url");
         route.BtmsLinkType.Should().Be(LinkType.Url);
+        route.BtmsHostHeader.Should().Be("btms-host-header");
         route.SendLegacyResponseToBtms.Should().BeTrue();
         route.RouteTo.Should().Be(RouteTo.Btms);
     }

--- a/BtmsGateway.Test/Services/Routing/TestRoutes.cs
+++ b/BtmsGateway.Test/Services/Routing/TestRoutes.cs
@@ -13,10 +13,10 @@ public static class TestRoutes
         },
         NamedLinks = new Dictionary<string, NamedLink>
         {
-            { "legacy_link_name_1", new NamedLink { Link = "http://legacy-link-url", LinkType = LinkType.Url } },
+            { "legacy_link_name_1", new NamedLink { Link = "http://legacy-link-url", LinkType = LinkType.Url, HostHeader = "legacy-host-header" } },
             { "legacy_link_name_2", new NamedLink { Link = "legacy-link-queue", LinkType = LinkType.Queue } },
             { "btms_link_name_1", new NamedLink { Link = "btms-link-queue", LinkType = LinkType.Queue } },
-            { "btms_link_name_2", new NamedLink { Link = "http://btms-link-url", LinkType = LinkType.Url } },
+            { "btms_link_name_2", new NamedLink { Link = "http://btms-link-url", LinkType = LinkType.Url, HostHeader = "btms-host-header" } },
         }
     };
     

--- a/BtmsGateway/BtmsGateway.csproj
+++ b/BtmsGateway/BtmsGateway.csproj
@@ -8,9 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="../Dockerfile">
-      <Link>Dockerfile</Link>
-    </Content>
     <Content Include="..\.dockerignore">
       <Link>Properties\SolutionFiles\.dockerignore</Link>
     </Content>
@@ -20,11 +17,11 @@
     <Content Include="..\.gitignore">
       <Link>Properties\SolutionFiles\.gitignore</Link>
     </Content>
+    <Content Include="..\Dockerfile">
+      <Link>Properties\SolutionFiles\Dockerfile</Link>
+    </Content>
     <Content Include="..\README.md">
       <Link>Properties\SolutionFiles\README.md</Link>
-    </Content>
-    <Content Include="..\run.sh">
-      <Link>Properties\SolutionFiles\run.sh</Link>
     </Content>
   </ItemGroup>
 

--- a/BtmsGateway/Middleware/RoutingInterceptor.cs
+++ b/BtmsGateway/Middleware/RoutingInterceptor.cs
@@ -15,7 +15,7 @@ public class RoutingInterceptor(RequestDelegate next, IMessageRouter messageRout
             
             var messageData = await MessageData.Create(context.Request, logger);
 
-            if (messageData.ShouldProcessRequest())
+            if (messageData.ShouldProcessRequest)
             {
                 logger.Information("{CorrelationId} Received routing instruction {HttpString} {Content}", messageData.CorrelationId, messageData.HttpString, messageData.OriginalContentAsString);
 

--- a/BtmsGateway/Services/Checking/CheckRouteConfig.cs
+++ b/BtmsGateway/Services/Checking/CheckRouteConfig.cs
@@ -11,6 +11,7 @@ public record HealthCheckUrl
     public required bool Disabled { get; init; }
     public required string Method { get; init; }
     public required string Url { get; init; }
+    public required string? HostHeader { get; init; }
 }
 
 public record CheckRouteUrl
@@ -19,6 +20,7 @@ public record CheckRouteUrl
     public required bool Disabled { get; init; }
     public required string CheckType { get; init; }
     public required string Method { get; init; }
+    public string? HostHeader { get; init; }
     public required string Url { get; init; }
     public Uri Uri => new(Url);
 }

--- a/BtmsGateway/Services/Checking/CheckRoutes.cs
+++ b/BtmsGateway/Services/Checking/CheckRoutes.cs
@@ -27,7 +27,7 @@ public class CheckRoutes(HealthCheckConfig healthCheckConfig, IHttpClientFactory
 
     private static CheckRouteUrl GetCheckRouteUrl(KeyValuePair<string, HealthCheckUrl> x)
     {
-        return new CheckRouteUrl { Name = x.Key, Method = x.Value.Method, Disabled = x.Value.Disabled, Url = x.Value.Url, CheckType = "HTTP" };
+        return new CheckRouteUrl { Name = x.Key, Method = x.Value.Method, Disabled = x.Value.Disabled, HostHeader = x.Value.HostHeader, Url = x.Value.Url, CheckType = "HTTP" };
     }
 
     private async Task<IEnumerable<CheckRouteResult>> CheckAll(CheckRouteUrl checkRouteUrl, CancellationTokenSource cts)
@@ -55,6 +55,7 @@ public class CheckRoutes(HealthCheckConfig healthCheckConfig, IHttpClientFactory
             logger.Information("Start checking HTTP request for {Url}", checkRouteUrl.Url);
             var client = clientFactory.CreateClient(Proxy.ProxyClientWithoutRetry);
             var request = new HttpRequestMessage(new HttpMethod(checkRouteUrl.Method), checkRouteUrl.Url);
+            if (checkRouteUrl.HostHeader != null) request.Headers.TryAddWithoutValidation("host", checkRouteUrl.HostHeader);
             stopwatch.Start();
             var response = await client.SendAsync(request, token);
             checkRouteResult = checkRouteResult with { ResponseResult = $"{response.StatusCode.ToString()} ({(int)response.StatusCode}){(includeResponseBody ? $"\n{await response.Content.ReadAsStringAsync(token)}" : string.Empty)}", Elapsed = stopwatch.Elapsed };

--- a/BtmsGateway/Services/Checking/CheckRoutes.cs
+++ b/BtmsGateway/Services/Checking/CheckRoutes.cs
@@ -35,11 +35,12 @@ public class CheckRoutes(HealthCheckConfig healthCheckConfig, IHttpClientFactory
         var checks = new List<Task<CheckRouteResult>>
         {
             CheckHttp(checkRouteUrl, false, cts.Token),
-            CheckHttp(checkRouteUrl with { CheckType = "HTTP HOST", Url = checkRouteUrl.Url.Replace(checkRouteUrl.Uri.PathAndQuery, "")}, false, cts.Token),
             CheckPing(checkRouteUrl, cts.Token),
             CheckNsLookup(checkRouteUrl, cts.Token),
             CheckDig(checkRouteUrl, cts.Token)
         };
+        var hostOnlyUrl = $"{checkRouteUrl.Uri.Scheme}://{checkRouteUrl.Uri.Host}";
+        if (checkRouteUrl.Url != hostOnlyUrl) checks.Insert(1, CheckHttp(checkRouteUrl with { CheckType = "HTTP HOST", Url = $"{checkRouteUrl.Uri.Scheme}://{checkRouteUrl.Uri.Host}" }, false, cts.Token));
         
         return await Task.WhenAll(checks);
     }

--- a/BtmsGateway/Services/Routing/MessageRouter.cs
+++ b/BtmsGateway/Services/Routing/MessageRouter.cs
@@ -24,8 +24,8 @@ public class MessageRouter(IHttpClientFactory clientFactory, IMessageRoutes mess
             var metrics = metricsHost.GetMetrics();
             var client = clientFactory.CreateClient(Proxy.RoutedClientWithRetry);
             var request = routingResult.ConvertedRoutedContentToJson 
-                ? messageData.CreateForwardingRequestAsJson(routingResult.FullRouteLink) 
-                : messageData.CreateForwardingRequestAsOriginal(routingResult.FullRouteLink);
+                ? messageData.CreateForwardingRequestAsJson(routingResult.FullRouteLink, routingResult.RouteHostHeader) 
+                : messageData.CreateForwardingRequestAsOriginal(routingResult.FullRouteLink, routingResult.RouteHostHeader);
             
             metrics.StartRoutedRequest();
             var response = await client.SendAsync(request);
@@ -51,8 +51,8 @@ public class MessageRouter(IHttpClientFactory clientFactory, IMessageRoutes mess
             var metrics = metricsHost.GetMetrics();
             var client = clientFactory.CreateClient(Proxy.ForkedClientWithRetry);
             var request = routingResult.ConvertedForkedContentToJson 
-                ? messageData.CreateForwardingRequestAsJson(routingResult.FullForkLink) 
-                : messageData.CreateForwardingRequestAsOriginal(routingResult.FullForkLink);
+                ? messageData.CreateForwardingRequestAsJson(routingResult.FullForkLink, routingResult.ForkHostHeader) 
+                : messageData.CreateForwardingRequestAsOriginal(routingResult.FullForkLink, routingResult.ForkHostHeader);
             
             metrics.StartForkedRequest();
             var response = await client.SendAsync(request);

--- a/BtmsGateway/Services/Routing/MessageRoutes.cs
+++ b/BtmsGateway/Services/Routing/MessageRoutes.cs
@@ -50,6 +50,8 @@ public class MessageRoutes : IMessageRoutes
                         RouteName = routeName,
                         FullRouteLink = $"{route.LegacyLink}{(route.LegacyLinkType == LinkType.Url ? routeUrlPath : null)}",
                         FullForkLink = $"{route.BtmsLink}{(route.BtmsLinkType == LinkType.Url ? routeUrlPath : null)}",
+                        RouteHostHeader = route.LegacyHostHeader,
+                        ForkHostHeader = route.BtmsHostHeader,
                         ConvertedForkedContentToJson = true,
                         UrlPath = routeUrlPath
                     },
@@ -59,6 +61,8 @@ public class MessageRoutes : IMessageRoutes
                         RouteName = routeName,
                         FullRouteLink = $"{route.BtmsLink}{(route.BtmsLinkType == LinkType.Url ? routeUrlPath : null)}",
                         FullForkLink = $"{route.LegacyLink}{(route.LegacyLinkType == LinkType.Url ? routeUrlPath : null)}",
+                        RouteHostHeader = route.BtmsHostHeader,
+                        ForkHostHeader = route.LegacyHostHeader,
                         ConvertedRoutedContentToJson = true,
                         UrlPath = routeUrlPath
                     },

--- a/BtmsGateway/Services/Routing/RoutingConfig.cs
+++ b/BtmsGateway/Services/Routing/RoutingConfig.cs
@@ -3,8 +3,9 @@ namespace BtmsGateway.Services.Routing;
 public record RoutingConfig
 {
     public RoutedLink[] AllRoutes =>
-        NamedRoutes.Join(NamedLinks, nr => nr.Value.LegacyLinkName, nl => nl.Key, (nr, nl) => new { Name = nr.Key, nr.Value.BtmsLinkName, LegacyLink = nl.Value.Link, LegacyLinkType = nl.Value.LinkType, nr.Value.SendRoutedResponseToFork, nr.Value.RouteTo })
-                   .Join(NamedLinks, nrl => nrl.BtmsLinkName, nl => nl.Key, (nrl, nl) => new RoutedLink { Name = nrl.Name, LegacyLink = nrl.LegacyLink.TrimEnd('/'), LegacyLinkType = nrl.LegacyLinkType, BtmsLink = nl.Value.Link.TrimEnd('/'), BtmsLinkType = nl.Value.LinkType, SendLegacyResponseToBtms = nrl.SendRoutedResponseToFork, RouteTo = nrl.RouteTo })
+        NamedRoutes.Join(NamedLinks, nr => nr.Value.LegacyLinkName, nl => nl.Key, (nr, nl) => new { Name = nr.Key, nr.Value.BtmsLinkName, LegacyLink = nl.Value.Link, nl.Value.LinkType, nl.Value.HostHeader, nr.Value.SendRoutedResponseToFork, nr.Value.RouteTo })
+                   .Join(NamedLinks, nrl => nrl.BtmsLinkName, nl => nl.Key, (nrl, nl) => new RoutedLink { Name = nrl.Name, LegacyLink = nrl.LegacyLink.TrimEnd('/'), LegacyLinkType = nrl.LinkType, LegacyHostHeader = nrl.HostHeader, 
+                       BtmsLink = nl.Value.Link.TrimEnd('/'), BtmsLinkType = nl.Value.LinkType, BtmsHostHeader = nl.Value.HostHeader, SendLegacyResponseToBtms = nrl.SendRoutedResponseToFork, RouteTo = nrl.RouteTo })
                    .ToArray();
     
     public required Dictionary<string, NamedRoute> NamedRoutes { get; init; } = [];
@@ -23,6 +24,7 @@ public record NamedLink
 {
     public required string Link { get; init; }
     public required LinkType LinkType { get; init; }
+    public string? HostHeader { get; init; }
 }
 
 public enum LinkType { Url, Queue }
@@ -32,8 +34,10 @@ public record RoutedLink
     public required string Name { get; init; }
     public required string LegacyLink { get; init; }
     public required LinkType LegacyLinkType { get; init; }
+    public string? LegacyHostHeader { get; init; }
     public required string BtmsLink { get; init; }
     public required LinkType BtmsLinkType { get; init; }
+    public string? BtmsHostHeader { get; init; }
     public required bool SendLegacyResponseToBtms { get; init; }
     public required RouteTo RouteTo { get; init; }
 }

--- a/BtmsGateway/Services/Routing/RoutingResult.cs
+++ b/BtmsGateway/Services/Routing/RoutingResult.cs
@@ -8,8 +8,10 @@ public record RoutingResult
     public bool RouteFound { get; init; }
     public bool RoutingSuccessful { get; init; }
     public string? FullRouteLink { get; init; }
+    public string? RouteHostHeader { get; init; }
     public bool ConvertedRoutedContentToJson { get; init; }
     public string? FullForkLink { get; init; }
+    public string? ForkHostHeader { get; init; }
     public bool ConvertedForkedContentToJson { get; init; }
     public string? UrlPath { get; init; }
     public string? ResponseContent { get; init; }

--- a/BtmsGateway/appsettings.json
+++ b/BtmsGateway/appsettings.json
@@ -118,11 +118,8 @@
       },
       "IBM_ALVS_IP": {
         "Method": "GET",
-        "Url": "https://10.62.146.246"
-      },
-      "IBM_ALVS_DNS": {
-        "Method": "GET",
-        "Url": "https://t2.secure.services.defra.gsi.gov.uk"
+        "Url": "https://10.62.146.246",
+        "HostHeader": "t2.secure.services.defra.gsi.gov.uk"
       }
     }
   }

--- a/BtmsGateway/appsettings.json
+++ b/BtmsGateway/appsettings.json
@@ -105,15 +105,15 @@
         "Url": "https://cdcm-eis.cds.dit1.n.mes.corp.hmrc.gov.uk"
       },
       "IPAFFS_Static_Vnet_Soap_Search": {
-        "Method": "POST",
+        "Method": "GET",
         "Url": "https://importnotification-api-static-snd.azure.defra.cloud/soapsearch/vnet/admin/health-check"
       },
       "IPAFFS_Integration_Notification": {
-        "Method": "POST",
+        "Method": "GET",
         "Url": "https://notification-microservice-integration.azurewebsites.net/admin/health-check"
       },
       "IPAFFS_Integration_Soap_Search": {
-        "Method": "POST",
+        "Method": "GET",
         "Url": "https://soapsearch-microservice-integration.azurewebsites.net/admin/health-check"
       },
       "IBM_ALVS_IP": {

--- a/BtmsGateway/appsettings.json
+++ b/BtmsGateway/appsettings.json
@@ -73,7 +73,8 @@
     "NamedLinks": {
       "Stub": {
         "LinkType": "Url",
-        "Link": "http://btms-gateway-stub.localtest.me:3092/"
+        "Link": "http://btms-gateway-stub.localtest.me:3092/",
+        "HostHeader": "btms-gateway-stub.localtest.me"
       },
       "ForkedStub": {
         "LinkType": "Url",

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,5 @@ ENV ASPNETCORE_FORWARDEDHEADERS_ENABLED=true
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-COPY --chmod=+x run.sh /run.sh
 EXPOSE 8085
-ENTRYPOINT ["/bin/bash", "/run.sh"]
+ENTRYPOINT ["dotnet", "BtmsGateway.dll"]

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-cp /etc/hosts hosts
-
-sed -i '$ a 10.62.146.246 t2.secure.services.defra.gsi.gov.uk' hosts
-
-cp hosts /etc/hosts
-
-dotnet BtmsGateway.dll


### PR DESCRIPTION
It turns out there is standard HTTP way to solve the issue of the URL (an IP address here) not matching the DNS name on the certificate. You need to set the header called "host" which is supported in .NET. That means it does not need the hosts file entry to match IP to DNS. It should not need the certificates to be installed as they are standard, publicly available root/intermediate certs, though that is a config thing we will discover after initial deployment.

Used the opportunity to add unit tests to a particularly complex area which highlighted some edge case weaknesses, now plugged, particularly around the use on the "Accept" header.