### PR TITLE
Added missing pollSearchCertificateResult route and matching tests.

### DIFF
--- a/BtmsGateway.Test/EndToEnd/DecisionNotificationFromAlvsToIpaffsTests.cs
+++ b/BtmsGateway.Test/EndToEnd/DecisionNotificationFromAlvsToIpaffsTests.cs
@@ -8,7 +8,7 @@ namespace BtmsGateway.Test.EndToEnd;
 
 public class DecisionNotificationFromAlvsToIpaffsTests : TargetRoutingTestBase
 {
-    private const string UrlPath = "/soapsearch/pre/sanco/traces_ws/sendALVSDecisionNotification";
+    private const string UrlPath = "/soapsearch/tst/sanco/traces_ws/sendALVSDecisionNotification";
 
     private readonly string _alvsRequestSoap = File.ReadAllText(Path.Combine(FixturesPath, "AlvsToIpaffsDecisionNotificationRequest.xml"));
     private readonly string _ipaffsResponseSoap = File.ReadAllText(Path.Combine(FixturesPath, "IpaffsResponse.xml"));

--- a/BtmsGateway.Test/EndToEnd/Fixtures/AlvsToIpaffsPollSearchCertificateResult.xml
+++ b/BtmsGateway.Test/EndToEnd/Fixtures/AlvsToIpaffsPollSearchCertificateResult.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<NS1:Envelope xmlns:NS1="http://www.w3.org/2003/05/soap-envelope">
+  <NS1:Header/>
+  <NS1:Body>
+    <NS2:CertificatePoll xmlns:NS2="traceswsns">
+      <NS2:XMLSchemaVersion>2.0</NS2:XMLSchemaVersion>
+      <NS2:UserIdentification>username</NS2:UserIdentification>
+      <NS2:UserPassword>password</NS2:UserPassword>
+      <NS2:SendingDate>2025-03-28 11:37</NS2:SendingDate>
+      <NS2:RequestIdentifier>1743161821984</NS2:RequestIdentifier>
+    </NS2:CertificatePoll>
+  </NS1:Body>
+</NS1:Envelope>

--- a/BtmsGateway.Test/EndToEnd/Fixtures/TargetRoutingConfig.json
+++ b/BtmsGateway.Test/EndToEnd/Fixtures/TargetRoutingConfig.json
@@ -61,7 +61,7 @@
       "RouteTo": "Legacy"
     },
     "ALVSSearchCertificateToIpaffs": {
-      "RoutePath": "/soapsearch/pre/sanco/traces_ws/searchCertificate",
+      "RoutePath": "/soapsearch/tst/sanco/traces_ws/searchCertificate",
       "MessageSubXPath": "CertificateRequest/Request",
       "Legend": "Legend",
       "LegacyLinkName": "AlvsIpaffs",
@@ -69,8 +69,17 @@
       "MessageBodyDepth": 2,
       "RouteTo": "Legacy"
     },
+    "ALVSPollSearchCertificateResultToIpaffs": {
+      "RoutePath": "/soapsearch/tst/sanco/traces_ws/pollSearchCertificateResult",
+      "MessageSubXPath": "CertificatePoll/RequestIdentifier",
+      "Legend": "IPAFFS Poll Certificate Result",
+      "LegacyLinkName": "AlvsIpaffs",
+      "BtmsLinkName": "None",
+      "MessageBodyDepth": 2,
+      "RouteTo": "Legacy"
+    },
     "ALVSDecisionNotificationToIpaffs": {
-      "RoutePath": "/soapsearch/pre/sanco/traces_ws/sendALVSDecisionNotification",
+      "RoutePath": "/soapsearch/tst/sanco/traces_ws/sendALVSDecisionNotification",
       "MessageSubXPath": "DecisionNotificationRequestPost/DecisionNotification",
       "Legend": "Legend",
       "LegacyLinkName": "AlvsIpaffs",

--- a/BtmsGateway.Test/EndToEnd/PollSearchCertificateResultFromAlvsToIpaffsTests.cs
+++ b/BtmsGateway.Test/EndToEnd/PollSearchCertificateResultFromAlvsToIpaffsTests.cs
@@ -6,22 +6,22 @@ using FluentAssertions;
 
 namespace BtmsGateway.Test.EndToEnd;
 
-public class SearchCertificateFromAlvsToIpaffsTests : TargetRoutingTestBase
+public class PollSearchCertificateResultFromAlvsToIpaffsTests : TargetRoutingTestBase
 {
-    private const string UrlPath = "/soapsearch/tst/sanco/traces_ws/searchCertificate";
+    private const string UrlPath = "/soapsearch/tst/sanco/traces_ws/pollSearchCertificateResult";
 
-    private readonly string _alvsRequestSoap = File.ReadAllText(Path.Combine(FixturesPath, "AlvsToIpaffsSearchCertificateRequest.xml"));
+    private readonly string _alvsRequestSoap = File.ReadAllText(Path.Combine(FixturesPath, "AlvsToIpaffsPollSearchCertificateResult.xml"));
     private readonly string _ipaffsResponseSoap = File.ReadAllText(Path.Combine(FixturesPath, "IpaffsResponse.xml"));
     private readonly StringContent _alvsRequestSoapContent;
 
-    public SearchCertificateFromAlvsToIpaffsTests()
+    public PollSearchCertificateResultFromAlvsToIpaffsTests()
     {
         _alvsRequestSoapContent = new StringContent(_alvsRequestSoap, Encoding.UTF8, MediaTypeNames.Application.Soap);
         TestWebServer.RoutedHttpHandler.SetNextResponse(content: _ipaffsResponseSoap, statusFunc: () => HttpStatusCode.Accepted);
     }
 
     [Fact]
-    public async Task When_receiving_search_certificate_from_alvs_Then_should_forward_to_ipaffs()
+    public async Task When_receiving_poll_search_certificate_result_from_alvs_Then_should_forward_to_ipaffs()
     {
         await HttpClient.PostAsync(UrlPath, _alvsRequestSoapContent);
 
@@ -30,7 +30,7 @@ public class SearchCertificateFromAlvsToIpaffsTests : TargetRoutingTestBase
     }
 
     [Fact]
-    public async Task When_receiving_search_certificate_from_alvs_Then_should_respond_with_ipaffs_response()
+    public async Task When_receiving_poll_search_certificate_result_from_alvs_Then_should_respond_with_ipaffs_response()
     {
         var response = await HttpClient.PostAsync(UrlPath, _alvsRequestSoapContent);
 

--- a/BtmsGateway/appsettings.json
+++ b/BtmsGateway/appsettings.json
@@ -74,7 +74,7 @@
         "RouteTo": "Legacy"
       },
       "ALVSClearanceRequestToIpaffs": {
-        "RoutePath": "/soapsearch/pre/sanco/traces_ws/sendALVSClearanceRequest",
+        "RoutePath": "/soapsearch/tst/sanco/traces_ws/sendALVSClearanceRequest",
         "MessageSubXPath": "ALVSClearanceRequestPost/ALVSClearanceRequest",
         "Legend": "IPAFFS Clearance Request",
         "LegacyLinkName": "Stub",
@@ -83,7 +83,7 @@
         "RouteTo": "Legacy"
       },
       "ALVSFinalisationNotificationToIpaffs": {
-        "RoutePath": "/soapsearch/pre/sanco/traces_ws/sendFinalisationNotificationRequest",
+        "RoutePath": "/soapsearch/tst/sanco/traces_ws/sendFinalisationNotificationRequest",
         "MessageSubXPath": "FinalisationNotificationRequestPost/FinalisationNotificationRequest",
         "Legend": "IPAFFS Finalisation",
         "LegacyLinkName": "Stub",
@@ -92,20 +92,29 @@
         "RouteTo": "Legacy"
       },
       "ALVSSearchCertificateToIpaffs": {
-        "RoutePath": "/soapsearch/pre/sanco/traces_ws/searchCertificate",
+        "RoutePath": "/soapsearch/tst/sanco/traces_ws/searchCertificate",
         "MessageSubXPath": "CertificateRequest/Request",
         "Legend": "IPAFFS Search Certificate",
         "LegacyLinkName": "Stub",
-        "BtmsLinkName": "ForkedStub",
+        "BtmsLinkName": "None",
+        "MessageBodyDepth": 2,
+        "RouteTo": "Legacy"
+      },
+      "ALVSPollSearchCertificateResultToIpaffs": {
+        "RoutePath": "/soapsearch/tst/sanco/traces_ws/pollSearchCertificateResult",
+        "MessageSubXPath": "CertificatePoll/RequestIdentifier",
+        "Legend": "IPAFFS Poll Certificate Result",
+        "LegacyLinkName": "Stub",
+        "BtmsLinkName": "None",
         "MessageBodyDepth": 2,
         "RouteTo": "Legacy"
       },
       "ALVSDecisionNotificationToIpaffs": {
-        "RoutePath": "/soapsearch/pre/sanco/traces_ws/sendALVSDecisionNotification",
+        "RoutePath": "/soapsearch/tst/sanco/traces_ws/sendALVSDecisionNotification",
         "MessageSubXPath": "DecisionNotificationRequestPost/DecisionNotification",
         "Legend": "IPAFFS ALVS Decision Notification",
         "LegacyLinkName": "Stub",
-        "BtmsLinkName": "ForkedStub",
+        "BtmsLinkName": "None",
         "MessageBodyDepth": 2,
         "RouteTo": "Legacy"
       },


### PR DESCRIPTION
The previous routes added did work, but we were also missing pollSearchCertificateResult.  This has now been added.