### PR TITLE
CDMS-637: handles html decoding of relevant messages

### DIFF
--- a/BtmsGateway.Test/BtmsGateway.Test.csproj
+++ b/BtmsGateway.Test/BtmsGateway.Test.csproj
@@ -64,5 +64,8 @@
     <None Update="Middleware\Fixtures\CdsErrorHandling.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Services\Converter\Fixtures\ClearanceRequestWithXmlCharacterEntityValues.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/BtmsGateway.Test/Services/Converter/Fixtures/ClearanceRequestWithXmlCharacterEntityValues.xml
+++ b/BtmsGateway.Test/Services/Converter/Fixtures/ClearanceRequestWithXmlCharacterEntityValues.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:oas="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+  <soap:Header>
+    <oas:Security soap:role="system" soap:mustUnderstand="true">
+      <oas:UsernameToken>
+        <oas:Username>systemID=ALVSHMRCCDS,ou=gsi systems,o=defra</oas:Username>
+        <oas:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText">password</oas:Password>
+      </oas:UsernameToken>
+    </oas:Security>
+  </soap:Header>
+  <soap:Body>
+    <ALVSClearanceRequest xmlns="http://submitimportdocumenthmrcfacade.types.esb.ws.cara.defra.com">
+      <ServiceHeader>
+        <SourceSystem>CDS</SourceSystem>
+        <DestinationSystem>ALVS</DestinationSystem>
+        <CorrelationId>1225712</CorrelationId>
+        <ServiceCallTimestamp>1730426760000</ServiceCallTimestamp>
+      </ServiceHeader>
+      <Header>
+        <EntryReference>24GBC1MRYLWODXRAR6</EntryReference>
+        <EntryVersionNumber>2</EntryVersionNumber>
+        <PreviousVersionNumber>1</PreviousVersionNumber>
+        <DeclarationUCR>4GB198244863000-KX-I6J2-184</DeclarationUCR>
+        <DeclarationPartNumber>null</DeclarationPartNumber>
+        <DeclarationType>S</DeclarationType>
+        <ArrivalDateTime>null</ArrivalDateTime>
+        <SubmitterTURN>GB331948590000</SubmitterTURN>
+        <DeclarantId>GB331948590000</DeclarantId>
+        <DeclarantName>GB331948590000</DeclarantName>
+        <DispatchCountryCode>PL</DispatchCountryCode>
+        <GoodsLocationCode>HULHULHULGVM</GoodsLocationCode>
+        <MasterUCR>null</MasterUCR>
+      </Header>
+      <Item>
+        <ItemNumber>1</ItemNumber>
+        <CustomsProcedureCode>4000000</CustomsProcedureCode>
+        <TaricCommodityCode>1601009110</TaricCommodityCode>
+        <GoodsDescription>XML Character Entities &quot; &apos; &lt; &gt; &amp;</GoodsDescription>
+        <ConsigneeId>GB198244863000</ConsigneeId>
+        <ConsigneeName>GB198244863000</ConsigneeName>
+        <ItemNetMass>60.95</ItemNetMass>
+        <ItemSupplementaryUnits>0</ItemSupplementaryUnits>
+        <ItemThirdQuantity>null</ItemThirdQuantity>
+        <ItemOriginCountryCode>SK</ItemOriginCountryCode>
+        <Document>
+          <DocumentCode>N853</DocumentCode>
+          <DocumentReference>GBCHD2024.5069802</DocumentReference>
+          <DocumentStatus>AE</DocumentStatus>
+          <DocumentControl>P</DocumentControl>
+          <DocumentQuantity>null</DocumentQuantity>
+        </Document>
+        <Check>
+          <CheckCode>H222</CheckCode>
+          <DepartmentCode>PHA</DepartmentCode>
+        </Check>
+      </Item>
+    </ALVSClearanceRequest>
+  </soap:Body>
+</soap:Envelope>

--- a/BtmsGateway.Test/Services/Converter/Fixtures/DecisionNotificationWithHtmlEncoding.xml
+++ b/BtmsGateway.Test/Services/Converter/Fixtures/DecisionNotificationWithHtmlEncoding.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NS1:Envelope xmlns:NS1="http://www.w3.org/2003/05/soap-envelope">
+  <NS1:Header>
+    <NS2:Security xmlns:NS2="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" NS1:role="system">
+      <NS2:UsernameToken>
+        <NS2:Username>ibmtest</NS2:Username>
+      </NS2:UsernameToken>
+    </NS2:Security>
+  </NS1:Header>
+  <NS1:Body>
+    <NS3:DecisionNotification xmlns:NS3="http://uk.gov.hmrc.ITSW2.ws">&lt;DecisionNotification xmlns="http://www.hmrc.gov.uk/webservices/itsw/ws/decisionnotification"&gt;&lt;ServiceHeader&gt;&lt;SourceSystem&gt;ALVS&lt;/SourceSystem&gt;&lt;DestinationSystem&gt;CDS&lt;/DestinationSystem&gt;&lt;CorrelationId&gt;000&lt;/CorrelationId&gt;&lt;ServiceCallTimestamp&gt;2023-06-30T07:34:14.405827&lt;/ServiceCallTimestamp&gt;&lt;/ServiceHeader&gt;&lt;Header&gt;&lt;EntryReference&gt;23GB1234567890ABC8&lt;/EntryReference&gt;&lt;EntryVersionNumber&gt;1&lt;/EntryVersionNumber&gt;&lt;DecisionNumber&gt;1&lt;/DecisionNumber&gt;&lt;/Header&gt;&lt;Item&gt;&lt;ItemNumber&gt;1&lt;/ItemNumber&gt;&lt;Check&gt;&lt;CheckCode&gt;H218&lt;/CheckCode&gt;&lt;DecisionCode&gt;C02&lt;/DecisionCode&gt;&lt;DecisionValidUntil&gt;202307042359&lt;/DecisionValidUntil&gt;&lt;/Check&gt;&lt;Check&gt;&lt;CheckCode&gt;H219&lt;/CheckCode&gt;&lt;DecisionCode&gt;C03&lt;/DecisionCode&gt;&lt;/Check&gt;&lt;Check&gt;&lt;CheckCode&gt;H223&lt;/CheckCode&gt;&lt;DecisionCode&gt;C03&lt;/DecisionCode&gt;&lt;/Check&gt;&lt;/Item&gt;&lt;Item&gt;&lt;ItemNumber&gt;2&lt;/ItemNumber&gt;&lt;Check&gt;&lt;CheckCode&gt;H219&lt;/CheckCode&gt;&lt;DecisionCode&gt;C03&lt;/DecisionCode&gt;&lt;/Check&gt;&lt;Check&gt;&lt;CheckCode&gt;H223&lt;/CheckCode&gt;&lt;DecisionCode&gt;C03&lt;/DecisionCode&gt;&lt;/Check&gt;&lt;/Item&gt;&lt;/DecisionNotification&gt;</NS3:DecisionNotification>
+  </NS1:Body>
+</NS1:Envelope>

--- a/BtmsGateway.Test/Services/Converter/SoapContentTests.cs
+++ b/BtmsGateway.Test/Services/Converter/SoapContentTests.cs
@@ -7,6 +7,13 @@ public class SoapContentTests
 {
     private const string Declaration = "<?xml version=\"1.0\" encoding=\"utf-8\"?>";
 
+    private static readonly string s_testDataPath = Path.Combine(
+        AppDomain.CurrentDomain.BaseDirectory,
+        "Services",
+        "Converter",
+        "Fixtures"
+    );
+
     [Fact]
     public void When_retrieving_message_at_single_element_xpath_against_soap_without_namespaces_Then_should_get_message()
     {
@@ -127,5 +134,17 @@ public class SoapContentTests
         var soapContent = new SoapContent(soap);
 
         soapContent.GetProperty("Message1/Data").Should().Be("111");
+    }
+
+    [Fact]
+    public void When_soap_value_contains_xml_character_entities_Then_the_soap_string_should_successfully_parse_into_soap_content()
+    {
+        var soap = File.ReadAllText(Path.Combine(s_testDataPath, "ClearanceRequestWithXmlCharacterEntityValues.xml"));
+
+        var soapContent = new SoapContent(soap);
+
+        soapContent
+            .SoapString.Should()
+            .Contain("<GoodsDescription>XML Character Entities &quot; &apos; &lt; &gt; &amp;</GoodsDescription>");
     }
 }

--- a/BtmsGateway.Test/Services/Converter/SoapToJsonConverterTests.cs
+++ b/BtmsGateway.Test/Services/Converter/SoapToJsonConverterTests.cs
@@ -36,6 +36,11 @@ public class SoapToJsonConverterTests
         "HMRCErrorNotification/HMRCErrorNotification",
         "HmrcErrorNotification.json"
     )]
+    [InlineData(
+        "DecisionNotificationWithHtmlEncoding.xml",
+        "DecisionNotification/DecisionNotification",
+        "DecisionNotification.json"
+    )]
     public void When_receiving_clearance_request_soap_Then_should_convert_to_json(
         string soapFileName,
         string messageSubXPath,

--- a/BtmsGateway/Services/Converter/SoapContent.cs
+++ b/BtmsGateway/Services/Converter/SoapContent.cs
@@ -5,13 +5,20 @@ namespace BtmsGateway.Services.Converter;
 
 public class SoapContent
 {
+    private static readonly string[] s_htmlCodedMessageNamespaces =
+    [
+        "http://www.hmrc.gov.uk/webservices/itsw/ws/decisionnotification",
+        "http://www.hmrc.gov.uk/webservices/itsw/ws/hmrcerrornotification",
+    ];
+    private static readonly string[] s_htmlCodedMessages = ["DecisionNotification", "HMRCErrorNotification"];
+
     public string? SoapString { get; }
 
     private readonly XmlNode? _soapXmlNode;
 
     public SoapContent(string? soapString)
     {
-        SoapString = HttpUtility.HtmlDecode(soapString);
+        SoapString = GetDecodedString(soapString);
         var soapXmlNode = GetElement(SoapString);
         _soapXmlNode = soapXmlNode;
     }
@@ -55,5 +62,20 @@ public class SoapContent
         var doc = new XmlDocument();
         doc.LoadXml(soapString);
         return doc.DocumentElement;
+    }
+
+    private static string? GetDecodedString(string? soapString)
+    {
+        // Dealing with the raw soap string here as we don't know how to decode and load it into XML without knowing the contained message type
+        if (
+            soapString is not null
+            && s_htmlCodedMessageNamespaces.Any(soapString.Contains)
+            && s_htmlCodedMessages.Any(soapString.Contains)
+        )
+        {
+            return HttpUtility.HtmlDecode(soapString);
+        }
+
+        return soapString;
     }
 }

--- a/BtmsGateway/Services/Converter/SoapContent.cs
+++ b/BtmsGateway/Services/Converter/SoapContent.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Web;
 using System.Xml;
 
@@ -5,6 +6,7 @@ namespace BtmsGateway.Services.Converter;
 
 public class SoapContent
 {
+    [SuppressMessage("SonarLint", "S5332", Justification = "The HTTP web links are XML namespaces so cannot change")]
     private static readonly string[] s_htmlCodedMessageNamespaces =
     [
         "http://www.hmrc.gov.uk/webservices/itsw/ws/decisionnotification",


### PR DESCRIPTION
- HTML Decodes ALVS to CDS Decision Notification and HMRC Error Notification only before passing the raw string into an XML Document
- All other messages are not HTML Decoded