### PR TITLE
CDMS-527: makes decision reason an array of elements

### DIFF
--- a/BtmsGateway.Test/Services/Converter/ClearanceDecisionToSoapConverterTests.cs
+++ b/BtmsGateway.Test/Services/Converter/ClearanceDecisionToSoapConverterTests.cs
@@ -41,6 +41,47 @@ public class ClearanceDecisionToSoapConverterTests
                         },
                     ],
                 },
+                new ClearanceDecisionItem
+                {
+                    ItemNumber = 2,
+                    Checks =
+                    [
+                        new ClearanceDecisionCheck
+                        {
+                            CheckCode = "H218",
+                            DecisionCode = "C02",
+                            DecisionsValidUntil = new DateTime(2025, 1, 1),
+                            DecisionReasons = ["Some decision reason 1", "Some decision reason 2"],
+                        },
+                    ],
+                },
+                new ClearanceDecisionItem
+                {
+                    ItemNumber = 3,
+                    Checks =
+                    [
+                        new ClearanceDecisionCheck
+                        {
+                            CheckCode = "H218",
+                            DecisionCode = "C02",
+                            DecisionsValidUntil = new DateTime(2025, 1, 1),
+                        },
+                    ],
+                },
+                new ClearanceDecisionItem
+                {
+                    ItemNumber = 4,
+                    Checks =
+                    [
+                        new ClearanceDecisionCheck
+                        {
+                            CheckCode = "H218",
+                            DecisionCode = "C02",
+                            DecisionsValidUntil = new DateTime(2025, 1, 1),
+                            DecisionReasons = [""],
+                        },
+                    ],
+                },
             ],
         };
 

--- a/BtmsGateway.Test/Services/Converter/Fixtures/ClearanceDecisionSoap.xml
+++ b/BtmsGateway.Test/Services/Converter/Fixtures/ClearanceDecisionSoap.xml
@@ -31,6 +31,32 @@
             <DecisionReason>Some decision reason</DecisionReason>
           </Check>
         </Item>
+        <Item>
+          <ItemNumber>2</ItemNumber>
+          <Check>
+            <CheckCode>H218</CheckCode>
+            <DecisionCode>C02</DecisionCode>
+            <DecisionValidUntil>202501010000</DecisionValidUntil>
+            <DecisionReason>Some decision reason 1</DecisionReason>
+            <DecisionReason>Some decision reason 2</DecisionReason>
+          </Check>
+        </Item>
+        <Item>
+          <ItemNumber>3</ItemNumber>
+          <Check>
+            <CheckCode>H218</CheckCode>
+            <DecisionCode>C02</DecisionCode>
+            <DecisionValidUntil>202501010000</DecisionValidUntil>
+          </Check>
+        </Item>
+        <Item>
+          <ItemNumber>4</ItemNumber>
+          <Check>
+            <CheckCode>H218</CheckCode>
+            <DecisionCode>C02</DecisionCode>
+            <DecisionValidUntil>202501010000</DecisionValidUntil>
+          </Check>
+        </Item>
       </DecisionNotification>
     </DecisionNotification>
   </soap:Body>

--- a/BtmsGateway/Services/Converter/ClearanceDecisionToSoapConverter.cs
+++ b/BtmsGateway/Services/Converter/ClearanceDecisionToSoapConverter.cs
@@ -57,9 +57,13 @@ public static class ClearanceDecisionToSoapConverter
             );
         }
 
-        if (check.DecisionReasons is not null)
+        if (check.DecisionReasons is null)
+            return checkElement;
+
+        foreach (var checkDecisionReason in check.DecisionReasons)
         {
-            checkElement.Add(new XElement("DecisionReason", string.Join(", ", check.DecisionReasons)));
+            if (!string.IsNullOrEmpty(checkDecisionReason))
+                checkElement.Add(new XElement("DecisionReason", checkDecisionReason));
         }
 
         return checkElement;


### PR DESCRIPTION
- makes decision reason on the outbound soap message an unbounded array of elements instead of a single concatenation of the reason strings.