### PR TITLE
CDMS-629 send only BTMS decision to CDS in test

### DIFF
--- a/BtmsGateway.Test/Consumers/ClearanceDecisionConsumerTests.cs
+++ b/BtmsGateway.Test/Consumers/ClearanceDecisionConsumerTests.cs
@@ -91,6 +91,7 @@ public class ClearanceDecisionConsumerTests
                 Arg.Any<string>(),
                 Arg.Any<MessagingConstants.DecisionSource>(),
                 Arg.Any<IHeaderDictionary>(),
+                Arg.Any<string>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(sendDecisionResult);
@@ -104,6 +105,7 @@ public class ClearanceDecisionConsumerTests
                 Arg.Any<string>(),
                 Arg.Any<MessagingConstants.DecisionSource>(),
                 Arg.Any<IHeaderDictionary>(),
+                Arg.Any<string>(),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -170,6 +172,7 @@ public class ClearanceDecisionConsumerTests
                 Arg.Any<string>(),
                 Arg.Any<MessagingConstants.DecisionSource>(),
                 Arg.Any<IHeaderDictionary>(),
+                Arg.Any<string>(),
                 Arg.Any<CancellationToken>()
             )
             .ThrowsAsync(new Exception("Something went wrong"));
@@ -193,6 +196,7 @@ public class ClearanceDecisionConsumerTests
                 Arg.Any<string>(),
                 Arg.Any<MessagingConstants.DecisionSource>(),
                 Arg.Any<IHeaderDictionary>(),
+                Arg.Any<string>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(sendDecisionResult);

--- a/BtmsGateway.Test/Services/Routing/MessageRouterTests.cs
+++ b/BtmsGateway.Test/Services/Routing/MessageRouterTests.cs
@@ -499,6 +499,7 @@ public class MessageRouterTests
                     Arg.Any<string>(),
                     Arg.Any<MessagingConstants.DecisionSource>(),
                     Arg.Any<HeaderDictionary>(),
+                    Arg.Any<string>(),
                     Arg.Any<CancellationToken>()
                 )
                 .Returns(
@@ -518,6 +519,7 @@ public class MessageRouterTests
                     Arg.Any<string>(),
                     Arg.Any<MessagingConstants.DecisionSource>(),
                     Arg.Any<HeaderDictionary>(),
+                    Arg.Any<string>(),
                     Arg.Any<CancellationToken>()
                 )
                 .ThrowsAsync<Exception>();

--- a/BtmsGateway/BtmsGateway.csproj
+++ b/BtmsGateway/BtmsGateway.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.ResourceUtilization" Version="8.10.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.10" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
+    <PackageReference Include="Microsoft.FeatureManagement" Version="4.0.0" />
     <PackageReference Include="Polly" Version="8.4.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />

--- a/BtmsGateway/Config/ConfigureServices.cs
+++ b/BtmsGateway/Config/ConfigureServices.cs
@@ -6,6 +6,7 @@ using BtmsGateway.Services.Metrics;
 using BtmsGateway.Services.Routing;
 using BtmsGateway.Utils.Http;
 using FluentValidation;
+using Microsoft.FeatureManagement;
 using ILogger = Serilog.ILogger;
 
 namespace BtmsGateway.Config;
@@ -51,5 +52,7 @@ public static class ConfigureServices
         builder.Services.AddSingleton<CheckRoutes>();
         builder.Services.AddSingleton<MetricsHost>();
         builder.Services.AddSingleton<IDecisionSender, DecisionSender>();
+
+        builder.Services.AddFeatureManagement(builder.Configuration.GetSection("FeatureFlags"));
     }
 }

--- a/BtmsGateway/Consumers/ClearanceDecisionConsumer.cs
+++ b/BtmsGateway/Consumers/ClearanceDecisionConsumer.cs
@@ -53,6 +53,7 @@ public class ClearanceDecisionConsumer(ITradeImportsDataApiClient api, IDecision
                 mrn,
                 soapMessage,
                 MessagingConstants.DecisionSource.Btms,
+                externalCorrelationId: customsDeclaration.ClearanceDecision.ExternalCorrelationId,
                 cancellationToken: cancellationToken
             );
 

--- a/BtmsGateway/Domain/Features.cs
+++ b/BtmsGateway/Domain/Features.cs
@@ -1,0 +1,6 @@
+namespace BtmsGateway.Domain;
+
+public static class Features
+{
+    public const string SendBtmsDecisionToCds = nameof(SendBtmsDecisionToCds);
+}

--- a/BtmsGateway/Domain/Features.cs
+++ b/BtmsGateway/Domain/Features.cs
@@ -2,5 +2,5 @@ namespace BtmsGateway.Domain;
 
 public static class Features
 {
-    public const string SendBtmsDecisionToCds = nameof(SendBtmsDecisionToCds);
+    public const string SendOnlyBtmsDecisionToCds = nameof(SendOnlyBtmsDecisionToCds);
 }

--- a/BtmsGateway/Services/Routing/DecisionSender.cs
+++ b/BtmsGateway/Services/Routing/DecisionSender.cs
@@ -14,18 +14,23 @@ public interface IDecisionSender
         string? decision,
         MessagingConstants.DecisionSource decisionSource,
         IHeaderDictionary? headers = null,
+        string? externalCorrelationId = null,
         CancellationToken cancellationToken = default
     );
 }
 
 public class DecisionSender : IDecisionSender
 {
+    private const string CorrelationIdHeaderName = "CorrelationId";
+    private const string AcceptHeaderName = "Accept";
+
     private readonly RoutingConfig? _routingConfig;
     private readonly IApiSender _apiSender;
     private readonly IFeatureManager _featureManager;
     private readonly ILogger _logger;
     private readonly Destination _btmsDecisionsComparerDestination;
     private readonly Destination _alvsDecisionComparerDestination;
+    private readonly Destination _btmsToCdsDestination;
 
     public DecisionSender(
         RoutingConfig? routingConfig,
@@ -41,6 +46,7 @@ public class DecisionSender : IDecisionSender
 
         _btmsDecisionsComparerDestination = GetDestination(MessagingConstants.Destinations.BtmsDecisionComparer);
         _alvsDecisionComparerDestination = GetDestination(MessagingConstants.Destinations.AlvsDecisionComparer);
+        _btmsToCdsDestination = GetDestination(MessagingConstants.Destinations.BtmsCds);
     }
 
     public async Task<RoutingResult> SendDecisionAsync(
@@ -48,6 +54,7 @@ public class DecisionSender : IDecisionSender
         string? decision,
         MessagingConstants.DecisionSource decisionSource,
         IHeaderDictionary? headers = null,
+        string? externalCorrelationId = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -84,15 +91,15 @@ public class DecisionSender : IDecisionSender
             );
             throw new DecisionComparisonException($"{mrn} Failed to send Decision to Decision Comparer.");
         }
-        
-        if (await _featureManager.IsEnabledAsync(Features.SendBtmsDecisionToCds) && decisionSource == MessagingConstants.DecisionSource.Btms)
-        {
-            
-        }
-        else
-        {
-            await ForwardDecisionAsync(mrn, decisionSource, comparerResponse, cancellationToken);
-        }
+
+        var cdsResponse = await ForwardDecisionAsync(
+            mrn,
+            decisionSource,
+            comparerResponse,
+            decision,
+            externalCorrelationId,
+            cancellationToken
+        );
 
         var fullLink =
             decisionSource == MessagingConstants.DecisionSource.Btms
@@ -107,20 +114,42 @@ public class DecisionSender : IDecisionSender
             RoutingSuccessful = true,
             FullRouteLink = fullLink,
             FullForkLink = fullLink,
-            StatusCode = comparerResponse.StatusCode,
-            ResponseContent = "Decision Comparer Result",
+            StatusCode = cdsResponse?.StatusCode ?? HttpStatusCode.NoContent,
+            ResponseContent = await GetResponseContentAsync(cdsResponse, cancellationToken),
         };
     }
 
-    private async Task ForwardDecisionAsync(
+    private async Task<HttpResponseMessage?> ForwardDecisionAsync(
         string? mrn,
         MessagingConstants.DecisionSource decisionSource,
         HttpResponseMessage? comparerResponse,
+        string originalDecision,
+        string? externalCorrelationId,
         CancellationToken cancellationToken
     )
     {
-        if (decisionSource == MessagingConstants.DecisionSource.Alvs)
+        if (
+            await _featureManager.IsEnabledAsync(Features.SendOnlyBtmsDecisionToCds)
+            && decisionSource == MessagingConstants.DecisionSource.Btms
+        )
         {
+            _logger.Debug("{MRN} Sending BTMS Decision to CDS.", mrn);
+
+            return await SendCdsFormattedSoapMessageAsync(
+                mrn,
+                originalDecision,
+                externalCorrelationId,
+                cancellationToken
+            );
+        }
+
+        if (
+            !await _featureManager.IsEnabledAsync(Features.SendOnlyBtmsDecisionToCds)
+            && decisionSource == MessagingConstants.DecisionSource.Alvs
+        )
+        {
+            _logger.Debug("{MRN} Sending Decision received from Decision Comparer to CDS.", mrn);
+
             var comparerDecision = await GetResponseContentAsync(comparerResponse, cancellationToken);
 
             if (string.IsNullOrWhiteSpace(comparerDecision))
@@ -139,7 +168,50 @@ public class DecisionSender : IDecisionSender
                 comparerDecision
             );
             // Just log decision for now. Eventually, in cut over, will send the Decision to CDS.
+            // Ensure original ALVS request headers are passed through and appended in SendCdsFormattedSoapMessageAsync!
+            // Pass the CDS response back out!
+            return null;
         }
+
+        return null;
+    }
+
+    private async Task<HttpResponseMessage?> SendCdsFormattedSoapMessageAsync(
+        string? mrn,
+        string soapMessage,
+        string? externalCorrelationId,
+        CancellationToken cancellationToken
+    )
+    {
+        var destination = string.Concat(_btmsToCdsDestination.Link, _btmsToCdsDestination.RoutePath);
+        var headers = new Dictionary<string, string> { { AcceptHeaderName, _btmsToCdsDestination.ContentType } };
+
+        if (!string.IsNullOrWhiteSpace(externalCorrelationId))
+            headers.Add(CorrelationIdHeaderName, externalCorrelationId);
+
+        var response = await _apiSender.SendSoapMessageAsync(
+            _btmsToCdsDestination.Method ?? "POST",
+            destination,
+            _btmsToCdsDestination.ContentType,
+            _btmsToCdsDestination.HostHeader,
+            headers,
+            soapMessage,
+            cancellationToken
+        );
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.Error(
+                "{MRN} Failed to send clearance decision to CDS. CDS Response Status Code: {StatusCode}, Reason: {Reason}, Content: {Content}",
+                mrn,
+                response.StatusCode,
+                response.ReasonPhrase,
+                await GetResponseContentAsync(response, cancellationToken)
+            );
+            throw new DecisionComparisonException($"{mrn} Failed to send clearance decision to CDS.");
+        }
+
+        return response;
     }
 
     private Destination GetDestination(string destinationKey)

--- a/BtmsGateway/Services/Routing/MessageRouter.cs
+++ b/BtmsGateway/Services/Routing/MessageRouter.cs
@@ -38,7 +38,8 @@ public class MessageRouter(
                     messageData.ContentMap.EntryReference,
                     messageData.OriginalSoapContent.SoapString,
                     MessagingConstants.DecisionSource.Alvs,
-                    messageData.Headers
+                    messageData.Headers,
+                    messageData.ContentMap.CorrelationId
                 ),
                 _ => routingResult,
             };
@@ -78,7 +79,8 @@ public class MessageRouter(
                     messageData.ContentMap.EntryReference,
                     messageData.OriginalSoapContent.SoapString,
                     MessagingConstants.DecisionSource.Alvs,
-                    messageData.Headers
+                    messageData.Headers,
+                    messageData.ContentMap.CorrelationId
                 ),
                 _ => routingResult,
             };

--- a/BtmsGateway/appsettings.Development.json
+++ b/BtmsGateway/appsettings.Development.json
@@ -46,5 +46,8 @@
   },
   "DecisionComparerApi": {
     "BaseAddress": "http://localhost:5001"
+  },
+  "FeatureFlags": {
+    "SendBtmsDecisionToCds": true
   }
 }

--- a/BtmsGateway/appsettings.Development.json
+++ b/BtmsGateway/appsettings.Development.json
@@ -48,6 +48,6 @@
     "BaseAddress": "http://localhost:5001"
   },
   "FeatureFlags": {
-    "SendBtmsDecisionToCds": true
+    "SendOnlyBtmsDecisionToCds": false
   }
 }

--- a/BtmsGateway/appsettings.json
+++ b/BtmsGateway/appsettings.json
@@ -245,5 +245,8 @@
   "DecisionComparerApi": {
     "BaseAddress": "https://trade-imports-decision-comparer.dev.cdp-int.defra.cloud",
     "Username": "BtmsGateway"
+  },
+  "FeatureFlags": {
+    "SendBtmsDecisionToCds": false
   }
 }

--- a/BtmsGateway/appsettings.json
+++ b/BtmsGateway/appsettings.json
@@ -247,6 +247,6 @@
     "Username": "BtmsGateway"
   },
   "FeatureFlags": {
-    "SendBtmsDecisionToCds": false
+    "SendOnlyBtmsDecisionToCds": false
   }
 }


### PR DESCRIPTION
- Feature flagged functionality to only send BTMS decisions to CDS during testing
- ALVS decision will be persisted to Decision Comparer but not forwarded onto CDS