### PR TITLE
Discard inbound error sub resource type if received

### DIFF
--- a/BtmsGateway.Test/BtmsGateway.Test.csproj
+++ b/BtmsGateway.Test/BtmsGateway.Test.csproj
@@ -10,8 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.SQS" Version="3.7.400.124" />
-    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.8.0" />
-    <PackageReference Include="Defra.TradeImportsDataApi.Domain" Version="0.6.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/BtmsGateway.Test/Consumers/ClearanceDecisionConsumerTests.cs
+++ b/BtmsGateway.Test/Consumers/ClearanceDecisionConsumerTests.cs
@@ -65,9 +65,10 @@ public class ClearanceDecisionConsumerTests
 
         var customsDeclaration = new CustomsDeclarationResponse(
             "24GB123456789AB012",
-            null,
+            ClearanceRequest: null,
             clearanceDecision,
-            null,
+            Finalisation: null,
+            InboundError: null,
             DateTime.Now,
             DateTime.Now,
             null
@@ -141,9 +142,10 @@ public class ClearanceDecisionConsumerTests
     {
         var customsDeclaration = new CustomsDeclarationResponse(
             "24GB123456789AB012",
-            null,
-            null,
-            null,
+            ClearanceRequest: null,
+            ClearanceDecision: null,
+            Finalisation: null,
+            InboundError: null,
             DateTime.Now,
             DateTime.Now,
             null
@@ -209,5 +211,36 @@ public class ClearanceDecisionConsumerTests
         thrownException
             .InnerException?.Message.Should()
             .Be("24GB123456789AB012 Failed to send clearance decision to Decision Comparer.");
+    }
+
+    [Fact]
+    public async Task When_processing_inbound_error_Then_discarded()
+    {
+        var resourceEvent = new ResourceEvent<CustomsDeclaration>
+        {
+            ResourceId = "24GB123456789AB012",
+            ResourceType = "CustomsDeclaration",
+            SubResourceType = "InboundError",
+            Operation = "Updated",
+        };
+
+        _context.Message.Returns(resourceEvent);
+
+        _tradeImportsDataApiClient
+            .GetCustomsDeclaration(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Throws(new Exception("BOOM!"));
+
+        await _consumer.OnHandle(_context, CancellationToken.None);
+
+        await _decisionSender
+            .DidNotReceive()
+            .SendDecisionAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<MessagingConstants.DecisionSource>(),
+                Arg.Any<IHeaderDictionary>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>()
+            );
     }
 }

--- a/BtmsGateway.Test/EndToEnd/EndToEndTestCollection.cs
+++ b/BtmsGateway.Test/EndToEnd/EndToEndTestCollection.cs
@@ -1,0 +1,7 @@
+namespace BtmsGateway.Test.EndToEnd;
+
+[CollectionDefinition(Name)]
+public class EndToEndTestCollection
+{
+    public const string Name = "End to End tests";
+}

--- a/BtmsGateway.Test/EndToEnd/GeneralEndToEndTests.cs
+++ b/BtmsGateway.Test/EndToEnd/GeneralEndToEndTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace BtmsGateway.Test.EndToEnd;
 
 [Trait("Dependence", "localstack")]
+[Collection(EndToEndTestCollection.Name)]
 public sealed class GeneralEndToEndTests : IDisposable
 {
     private bool _disposed;

--- a/BtmsGateway.Test/EndToEnd/TargetRoutingTestBase.cs
+++ b/BtmsGateway.Test/EndToEnd/TargetRoutingTestBase.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace BtmsGateway.Test.EndToEnd;
 
 [Trait("Dependence", "localstack")]
+[Collection(EndToEndTestCollection.Name)]
 public abstract class TargetRoutingTestBase : IDisposable
 {
     private bool _disposed;

--- a/BtmsGateway.sln.DotSettings
+++ b/BtmsGateway.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=btms/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/BtmsGateway/BtmsGateway.csproj
+++ b/BtmsGateway/BtmsGateway.csproj
@@ -28,8 +28,7 @@
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.400" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.400.133" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.400.124" />
-    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.8.0" />
-    <PackageReference Include="Defra.TradeImportsDataApi.Domain" Version="0.6.0" />
+    <PackageReference Include="Defra.TradeImportsDataApi.Api.Client" Version="0.18.0" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.3" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.12.3" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2" />

--- a/BtmsGateway/Consumers/ClearanceDecisionConsumer.cs
+++ b/BtmsGateway/Consumers/ClearanceDecisionConsumer.cs
@@ -19,13 +19,19 @@ public class ClearanceDecisionConsumer(ITradeImportsDataApiClient api, IDecision
         CancellationToken cancellationToken
     )
     {
-        logger.Information("Clearance Decision Resource Event received from queue.");
-
         if (context.Message is null)
         {
             logger.Error("Invalid message received from queue {Message}.", context.Message);
             throw new InvalidOperationException($"Invalid message received from queue {context.Message}.");
         }
+
+        if (context.Message.SubResourceType == nameof(CustomsDeclaration.InboundError))
+        {
+            logger.Information("Inbound Error Resource Event received from queue, discarding.");
+            return;
+        }
+
+        logger.Information("Clearance Decision Resource Event received from queue.");
 
         var mrn = context.Message.ResourceId;
 


### PR DESCRIPTION
As per PR title.

This is just enough code for now to allow us to create a subscription rule of the gateway so it will receive inbound errors.