### PR TITLE
Temp handling of processing errors and only handle ClearanceDecision sub resource type of a CustomsDeclaration resource event

### DIFF
--- a/BtmsGateway.Test/Consumers/ClearanceDecisionConsumerTests.cs
+++ b/BtmsGateway.Test/Consumers/ClearanceDecisionConsumerTests.cs
@@ -8,11 +8,11 @@ using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 using Defra.TradeImportsDataApi.Domain.Events;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using NSubstitute.ReturnsExtensions;
-using SlimMessageBus;
-using ILogger = Serilog.ILogger;
 
 namespace BtmsGateway.Test.Consumers;
 
@@ -21,22 +21,19 @@ public class ClearanceDecisionConsumerTests
     private readonly ITradeImportsDataApiClient _tradeImportsDataApiClient =
         Substitute.For<ITradeImportsDataApiClient>();
     private readonly IDecisionSender _decisionSender = Substitute.For<IDecisionSender>();
-    private readonly ILogger _logger = Substitute.For<ILogger>();
-    private readonly IConsumerContext<ResourceEvent<CustomsDeclaration>> _context = Substitute.For<
-        IConsumerContext<ResourceEvent<CustomsDeclaration>>
-    >();
-    private ClearanceDecisionConsumer _consumer;
+    private readonly ILogger<ClearanceDecisionConsumer> _logger = NullLogger<ClearanceDecisionConsumer>.Instance;
+    private readonly ResourceEvent<CustomsDeclaration> _message;
+    private readonly ClearanceDecisionConsumer _consumer;
 
     public ClearanceDecisionConsumerTests()
     {
-        var resourceEvent = new ResourceEvent<CustomsDeclaration>
+        _message = new ResourceEvent<CustomsDeclaration>
         {
             ResourceId = "24GB123456789AB012",
             ResourceType = "CustomsDeclaration",
+            SubResourceType = "ClearanceDecision",
             Operation = "Updated",
         };
-
-        _context.Message.Returns(resourceEvent);
 
         var clearanceDecision = new ClearanceDecision
         {
@@ -97,7 +94,7 @@ public class ClearanceDecisionConsumerTests
             )
             .Returns(sendDecisionResult);
 
-        await _consumer.OnHandle(_context, CancellationToken.None);
+        await _consumer.OnHandle(_message, CancellationToken.None);
 
         await _decisionSender
             .Received(1)
@@ -112,23 +109,12 @@ public class ClearanceDecisionConsumerTests
     }
 
     [Fact]
-    public async Task When_message_is_null_Then_exception_is_thrown()
-    {
-        _context.Message.ReturnsNull();
-
-        var thrownException = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            _consumer.OnHandle(_context, CancellationToken.None)
-        );
-        thrownException.Message.Should().StartWith("Invalid message received from queue");
-    }
-
-    [Fact]
     public async Task When_api_customs_declaration_is_null_Then_exception_is_thrown()
     {
         _tradeImportsDataApiClient.GetCustomsDeclaration(Arg.Any<string>(), Arg.Any<CancellationToken>()).ReturnsNull();
 
         var thrownException = await Assert.ThrowsAsync<ClearanceDecisionProcessingException>(() =>
-            _consumer.OnHandle(_context, CancellationToken.None)
+            _consumer.OnHandle(_message, CancellationToken.None)
         );
         thrownException.Message.Should().Be("24GB123456789AB012 Failed to process clearance decision resource event.");
         thrownException.InnerException.Should().BeAssignableTo<InvalidOperationException>();
@@ -156,7 +142,7 @@ public class ClearanceDecisionConsumerTests
             .Returns(customsDeclaration);
 
         var thrownException = await Assert.ThrowsAsync<ClearanceDecisionProcessingException>(() =>
-            _consumer.OnHandle(_context, CancellationToken.None)
+            _consumer.OnHandle(_message, CancellationToken.None)
         );
         thrownException.Message.Should().Be("24GB123456789AB012 Failed to process clearance decision resource event.");
         thrownException.InnerException.Should().BeAssignableTo<InvalidOperationException>();
@@ -180,7 +166,7 @@ public class ClearanceDecisionConsumerTests
             .ThrowsAsync(new Exception("Something went wrong"));
 
         var thrownException = await Assert.ThrowsAsync<ClearanceDecisionProcessingException>(() =>
-            _consumer.OnHandle(_context, CancellationToken.None)
+            _consumer.OnHandle(_message, CancellationToken.None)
         );
         thrownException.Message.Should().Be("24GB123456789AB012 Failed to process clearance decision resource event.");
         thrownException.InnerException.Should().BeAssignableTo<Exception>();
@@ -204,43 +190,12 @@ public class ClearanceDecisionConsumerTests
             .Returns(sendDecisionResult);
 
         var thrownException = await Assert.ThrowsAsync<ClearanceDecisionProcessingException>(() =>
-            _consumer.OnHandle(_context, CancellationToken.None)
+            _consumer.OnHandle(_message, CancellationToken.None)
         );
         thrownException.Message.Should().Be("24GB123456789AB012 Failed to process clearance decision resource event.");
         thrownException.InnerException.Should().BeAssignableTo<ClearanceDecisionProcessingException>();
         thrownException
             .InnerException?.Message.Should()
             .Be("24GB123456789AB012 Failed to send clearance decision to Decision Comparer.");
-    }
-
-    [Fact]
-    public async Task When_processing_inbound_error_Then_discarded()
-    {
-        var resourceEvent = new ResourceEvent<CustomsDeclaration>
-        {
-            ResourceId = "24GB123456789AB012",
-            ResourceType = "CustomsDeclaration",
-            SubResourceType = "InboundError",
-            Operation = "Updated",
-        };
-
-        _context.Message.Returns(resourceEvent);
-
-        _tradeImportsDataApiClient
-            .GetCustomsDeclaration(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Throws(new Exception("BOOM!"));
-
-        await _consumer.OnHandle(_context, CancellationToken.None);
-
-        await _decisionSender
-            .DidNotReceive()
-            .SendDecisionAsync(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<MessagingConstants.DecisionSource>(),
-                Arg.Any<IHeaderDictionary>(),
-                Arg.Any<string>(),
-                Arg.Any<CancellationToken>()
-            );
     }
 }

--- a/BtmsGateway.Test/Consumers/ConsumerMediatorTests.cs
+++ b/BtmsGateway.Test/Consumers/ConsumerMediatorTests.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using BtmsGateway.Consumers;
+using BtmsGateway.Exceptions;
+using BtmsGateway.Extensions;
+using BtmsGateway.Services.Routing;
+using Defra.TradeImportsDataApi.Api.Client;
+using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using Defra.TradeImportsDataApi.Domain.Events;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using SlimMessageBus;
+
+namespace BtmsGateway.Test.Consumers;
+
+public class ConsumerMediatorTests
+{
+    [Fact]
+    public async Task WhenCustomsDeclaration_ShouldPassThroughToClearanceDecisionConsumer()
+    {
+        var context = Substitute.For<IConsumerContext>();
+        context.Headers.Returns(
+            new Dictionary<string, object>
+            {
+                { MessageBusHeaders.ResourceType, ResourceEventResourceTypes.CustomsDeclaration },
+            }
+        );
+        var subject = new ConsumerMediator(
+            Substitute.For<ITradeImportsDataApiClient>(),
+            Substitute.For<IDecisionSender>(),
+            Substitute.For<ILoggerFactory>()
+        )
+        {
+            Context = context,
+        };
+
+        var message = JsonSerializer.Deserialize<JsonElement>(
+            JsonSerializer.Serialize(
+                new ResourceEvent<CustomsDeclaration>
+                {
+                    ResourceId = "mrn",
+                    ResourceType = ResourceEventResourceTypes.CustomsDeclaration,
+                    Operation = ResourceEventOperations.Created,
+                    SubResourceType = ResourceEventSubResourceTypes.ClearanceDecision,
+                }
+            )
+        );
+
+        var act = async () => await subject.OnHandle(message, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ClearanceDecisionProcessingException>();
+    }
+
+    [Fact]
+    public async Task WhenProcessingError_ShouldNotThrow()
+    {
+        var context = Substitute.For<IConsumerContext>();
+        context.Headers.Returns(
+            new Dictionary<string, object>
+            {
+                { MessageBusHeaders.ResourceType, ResourceEventResourceTypes.ProcessingError },
+            }
+        );
+        var subject = new ConsumerMediator(
+            Substitute.For<ITradeImportsDataApiClient>(),
+            Substitute.For<IDecisionSender>(),
+            Substitute.For<ILoggerFactory>()
+        )
+        {
+            Context = context,
+        };
+
+        var message = JsonSerializer.Deserialize<JsonElement>(
+            JsonSerializer.Serialize(
+                new ResourceEvent<CustomsDeclaration>
+                {
+                    ResourceId = "mrn",
+                    ResourceType = ResourceEventResourceTypes.ProcessingError,
+                    Operation = ResourceEventOperations.Created,
+                }
+            )
+        );
+
+        var act = async () => await subject.OnHandle(message, CancellationToken.None);
+
+        await act.Should().NotThrowAsync<ClearanceDecisionProcessingException>();
+    }
+
+    [Fact]
+    public async Task WhenUnsupportedResourceType_ShouldNotThrow()
+    {
+        var context = Substitute.For<IConsumerContext>();
+        context.Headers.Returns(
+            new Dictionary<string, object>
+            {
+                { MessageBusHeaders.ResourceType, ResourceEventResourceTypes.ImportPreNotification },
+            }
+        );
+        var subject = new ConsumerMediator(
+            Substitute.For<ITradeImportsDataApiClient>(),
+            Substitute.For<IDecisionSender>(),
+            Substitute.For<ILoggerFactory>()
+        )
+        {
+            Context = context,
+        };
+
+        var message = JsonSerializer.Deserialize<JsonElement>(
+            JsonSerializer.Serialize(
+                new ResourceEvent<CustomsDeclaration>
+                {
+                    ResourceId = "mrn",
+                    ResourceType = ResourceEventResourceTypes.ImportPreNotification,
+                    Operation = ResourceEventOperations.Created,
+                }
+            )
+        );
+
+        var act = async () => await subject.OnHandle(message, CancellationToken.None);
+
+        await act.Should().NotThrowAsync<ClearanceDecisionProcessingException>();
+    }
+}

--- a/BtmsGateway.Test/EndToEnd/EndToEndTestCollection.cs
+++ b/BtmsGateway.Test/EndToEnd/EndToEndTestCollection.cs
@@ -1,7 +1,0 @@
-namespace BtmsGateway.Test.EndToEnd;
-
-[CollectionDefinition(Name)]
-public class EndToEndTestCollection
-{
-    public const string Name = "End to End tests";
-}

--- a/BtmsGateway.Test/EndToEnd/GeneralEndToEndTests.cs
+++ b/BtmsGateway.Test/EndToEnd/GeneralEndToEndTests.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.DependencyInjection;
 namespace BtmsGateway.Test.EndToEnd;
 
 [Trait("Dependence", "localstack")]
-[Collection(EndToEndTestCollection.Name)]
 public sealed class GeneralEndToEndTests : IDisposable
 {
     private bool _disposed;

--- a/BtmsGateway.Test/EndToEnd/TargetRoutingTestBase.cs
+++ b/BtmsGateway.Test/EndToEnd/TargetRoutingTestBase.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.DependencyInjection;
 namespace BtmsGateway.Test.EndToEnd;
 
 [Trait("Dependence", "localstack")]
-[Collection(EndToEndTestCollection.Name)]
 public abstract class TargetRoutingTestBase : IDisposable
 {
     private bool _disposed;

--- a/BtmsGateway.Test/TestUtils/AsyncWaiter.cs
+++ b/BtmsGateway.Test/TestUtils/AsyncWaiter.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics;
+
+namespace BtmsGateway.Test.TestUtils;
+
+public static class AsyncWaiter
+{
+    private static readonly TimeSpan s_defaultDelay = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan s_defaultTimeout = TimeSpan.FromSeconds(30);
+
+    public static async Task<bool> WaitForAsync(Func<Task<bool>> condition)
+    {
+        var timer = Stopwatch.StartNew();
+
+        while (true)
+        {
+            if (await condition())
+                return true;
+
+            if (timer.Elapsed > s_defaultTimeout)
+                return false;
+
+            await Task.Delay(s_defaultDelay);
+        }
+    }
+}

--- a/BtmsGateway.Test/TestUtils/TestWebServer.cs
+++ b/BtmsGateway.Test/TestUtils/TestWebServer.cs
@@ -80,7 +80,21 @@ public class TestWebServer : IDisposable
 
         _app.RunAsync();
 
-        HttpServiceClient.GetAsync("/health").GetAwaiter().GetResult();
+        AsyncWaiter
+            .WaitForAsync(async () =>
+            {
+                try
+                {
+                    var response = await HttpServiceClient.GetAsync("/health");
+                    return response.IsSuccessStatusCode;
+                }
+                catch
+                {
+                    return false;
+                }
+            })
+            .GetAwaiter()
+            .GetResult();
     }
 
     public void Dispose()

--- a/BtmsGateway.Test/TestUtils/TestWebServer.cs
+++ b/BtmsGateway.Test/TestUtils/TestWebServer.cs
@@ -80,7 +80,7 @@ public class TestWebServer : IDisposable
 
         _app.RunAsync();
 
-        //var response = HttpServiceClient.GetAsync("/health").GetAwaiter().GetResult();
+        HttpServiceClient.GetAsync("/health").GetAwaiter().GetResult();
     }
 
     public void Dispose()

--- a/BtmsGateway.Test/TestUtils/TestWebServer.cs
+++ b/BtmsGateway.Test/TestUtils/TestWebServer.cs
@@ -79,6 +79,8 @@ public class TestWebServer : IDisposable
         _app = app;
 
         _app.RunAsync();
+
+        //var response = HttpServiceClient.GetAsync("/health").GetAwaiter().GetResult();
     }
 
     public void Dispose()

--- a/BtmsGateway/Consumers/ClearanceDecisionConsumer.cs
+++ b/BtmsGateway/Consumers/ClearanceDecisionConsumer.cs
@@ -7,33 +7,29 @@ using Defra.TradeImportsDataApi.Api.Client;
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 using Defra.TradeImportsDataApi.Domain.Events;
 using SlimMessageBus;
-using ILogger = Serilog.ILogger;
 
 namespace BtmsGateway.Consumers;
 
-public class ClearanceDecisionConsumer(ITradeImportsDataApiClient api, IDecisionSender decisionSender, ILogger logger)
-    : IConsumer<IConsumerContext<ResourceEvent<CustomsDeclaration>>>
+public class ClearanceDecisionConsumer(
+    ITradeImportsDataApiClient api,
+    IDecisionSender decisionSender,
+    ILogger<ClearanceDecisionConsumer> logger
+) : IConsumer<ResourceEvent<CustomsDeclaration>>
 {
-    public async Task OnHandle(
-        IConsumerContext<ResourceEvent<CustomsDeclaration>> context,
-        CancellationToken cancellationToken
-    )
+    public async Task OnHandle(ResourceEvent<CustomsDeclaration> message, CancellationToken cancellationToken)
     {
-        if (context.Message is null)
+        if (message.SubResourceType != ResourceEventSubResourceTypes.ClearanceDecision)
         {
-            logger.Error("Invalid message received from queue {Message}.", context.Message);
-            throw new InvalidOperationException($"Invalid message received from queue {context.Message}.");
-        }
-
-        if (context.Message.SubResourceType == nameof(CustomsDeclaration.InboundError))
-        {
-            logger.Information("Inbound Error Resource Event received from queue, discarding.");
+            logger.LogInformation(
+                "Customs Declaration Sub Resource Type {SubResourceType} skipped.",
+                message.SubResourceType
+            );
             return;
         }
 
-        logger.Information("Clearance Decision Resource Event received from queue.");
+        logger.LogInformation("Clearance Decision Resource Event received from queue.");
 
-        var mrn = context.Message.ResourceId;
+        var mrn = message.ResourceId;
 
         try
         {
@@ -41,13 +37,13 @@ public class ClearanceDecisionConsumer(ITradeImportsDataApiClient api, IDecision
 
             if (customsDeclaration is null)
             {
-                logger.Error("{MRN} Customs Declaration not found from Data API.", mrn);
+                logger.LogError("{MRN} Customs Declaration not found from Data API.", mrn);
                 throw new InvalidOperationException($"{mrn} Customs Declaration not found from Data API.");
             }
 
             if (customsDeclaration.ClearanceDecision is null)
             {
-                logger.Error("{MRN} Customs Declaration does not contain a Clearance Decision.", mrn);
+                logger.LogError("{MRN} Customs Declaration does not contain a Clearance Decision.", mrn);
                 throw new InvalidOperationException(
                     $"{mrn} Customs Declaration does not contain a Clearance Decision."
                 );
@@ -65,7 +61,7 @@ public class ClearanceDecisionConsumer(ITradeImportsDataApiClient api, IDecision
 
             if (!result.StatusCode.IsSuccessStatusCode())
             {
-                logger.Error(
+                logger.LogError(
                     "{MRN} Failed to send clearance decision to Decision Comparer. Decision Comparer Response Status Code: {StatusCode}, Reason: {Reason}, Content: {Content}",
                     mrn,
                     result.StatusCode,
@@ -77,14 +73,14 @@ public class ClearanceDecisionConsumer(ITradeImportsDataApiClient api, IDecision
                 );
             }
 
-            logger.Information(
+            logger.LogInformation(
                 "{MRN} Clearance Decision Resource Event successfully processed by ClearanceDecisionConsumer.",
                 mrn
             );
         }
         catch (Exception ex)
         {
-            logger.Error(ex, "{MRN} Failed to process clearance decision resource event.", mrn);
+            logger.LogError(ex, "{MRN} Failed to process clearance decision resource event.", mrn);
             throw new ClearanceDecisionProcessingException(
                 $"{mrn} Failed to process clearance decision resource event.",
                 ex

--- a/BtmsGateway/Consumers/ConsumerMediator.cs
+++ b/BtmsGateway/Consumers/ConsumerMediator.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using BtmsGateway.Extensions;
+using BtmsGateway.Services.Routing;
+using Defra.TradeImportsDataApi.Api.Client;
+using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using Defra.TradeImportsDataApi.Domain.Events;
+using Defra.TradeImportsDataApi.Domain.ProcessingErrors;
+using SlimMessageBus;
+
+namespace BtmsGateway.Consumers;
+
+public class ConsumerMediator(
+    ITradeImportsDataApiClient api,
+    IDecisionSender decisionSender,
+    ILoggerFactory loggerFactory
+) : IConsumer<JsonElement>, IConsumerWithContext
+{
+    private readonly ILogger<ConsumerMediator> _logger = loggerFactory.CreateLogger<ConsumerMediator>();
+
+    public IConsumerContext Context { get; set; } = null!;
+
+    public Task OnHandle(JsonElement message, CancellationToken cancellationToken)
+    {
+        var resourceType = Context.GetResourceType();
+
+        return resourceType switch
+        {
+            ResourceEventResourceTypes.CustomsDeclaration => HandleCustomsDeclaration(message, cancellationToken),
+            ResourceEventResourceTypes.ProcessingError => HandleProcessingError(message),
+            _ => HandleUnknown(resourceType),
+        };
+    }
+
+    private Task HandleCustomsDeclaration(JsonElement message, CancellationToken cancellationToken)
+    {
+        var consumer = new ClearanceDecisionConsumer(
+            api,
+            decisionSender,
+            loggerFactory.CreateLogger<ClearanceDecisionConsumer>()
+        );
+
+        return consumer.OnHandle(Deserialize<CustomsDeclaration>(message), cancellationToken);
+    }
+
+    private Task HandleProcessingError(JsonElement message)
+    {
+        var @event = Deserialize<ProcessingError>(message);
+
+        _logger.LogInformation("Processing Error Resource Event received from queue: {ProcessingError}", @event);
+
+        return Task.CompletedTask;
+    }
+
+    private Task HandleUnknown(string resourceType)
+    {
+        _logger.LogWarning("No Consumer for Resource Type: {ResourceType}", resourceType);
+
+        return Task.CompletedTask;
+    }
+
+    private static ResourceEvent<T> Deserialize<T>(JsonElement message) =>
+        message.Deserialize<ResourceEvent<T>>()
+        ?? throw new InvalidOperationException("Invalid message received from queue.");
+}

--- a/BtmsGateway/Extensions/AmazonConsumerExtensions.cs
+++ b/BtmsGateway/Extensions/AmazonConsumerExtensions.cs
@@ -1,7 +1,6 @@
+using System.Text.Json;
 using BtmsGateway.Config;
 using BtmsGateway.Consumers;
-using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
-using Defra.TradeImportsDataApi.Domain.Events;
 using SlimMessageBus.Host;
 using SlimMessageBus.Host.AmazonSQS;
 using SlimMessageBus.Host.Serialization.SystemTextJson;
@@ -28,8 +27,8 @@ public static class AmazonConsumerExtensions
 
         messageBusBuilder.AddJsonSerializer();
 
-        messageBusBuilder.Consume<ResourceEvent<CustomsDeclaration>>(x =>
-            x.WithConsumerOfContext<ClearanceDecisionConsumer>().Queue(options.OutboundClearanceDecisionsQueueName)
+        messageBusBuilder.Consume<JsonElement>(x =>
+            x.WithConsumer<ConsumerMediator>().Queue(options.OutboundClearanceDecisionsQueueName)
         );
     }
 }

--- a/BtmsGateway/Extensions/ConsumerContextExtensions.cs
+++ b/BtmsGateway/Extensions/ConsumerContextExtensions.cs
@@ -1,0 +1,21 @@
+using SlimMessageBus;
+
+namespace BtmsGateway.Extensions;
+
+public static class MessageBusHeaders
+{
+    public const string ResourceType = nameof(ResourceType);
+}
+
+public static class ConsumerContextExtensions
+{
+    public static string GetResourceType(this IConsumerContext consumerContext)
+    {
+        if (consumerContext.Headers.TryGetValue(MessageBusHeaders.ResourceType, out var value))
+        {
+            return value.ToString()!;
+        }
+
+        return string.Empty;
+    }
+}


### PR DESCRIPTION
Back our previous logic that handled the InboundError sub resource type, however still allow processing of the main customs declaration, which is only acted on if the clearance decision is being created/updated.

Add mediator consumer that allows different resource events to be processed.

Add a wait within the `TestWebServer` construction logic that polls the /health endpoint and will only proceed once it's successful. Hopefully this will reduce flakiness of tests in pipeline.