### PR TITLE
Configures health check to allow specific statuses on particular routes.

### DIFF
--- a/BtmsGateway/Services/Checking/CheckRouteConfig.cs
+++ b/BtmsGateway/Services/Checking/CheckRouteConfig.cs
@@ -14,6 +14,7 @@ public record HealthCheckUrl
     public required string Url { get; init; }
     public string? HostHeader { get; init; }
     public required bool IncludeInAutomatedHealthCheck { get; init; }
+    public int[]? AdditionalSuccessStatuses { get; init; }
 }
 
 public record CheckRouteUrl

--- a/BtmsGateway/appsettings.json
+++ b/BtmsGateway/appsettings.json
@@ -223,7 +223,8 @@
         "Method": "GET",
         "Url": "https://10.102.9.31/ws/CDS/defra/alvsclearanceinbound/v1",
         "HostHeader": "syst32.hmrc.gov.uk",
-        "IncludeInAutomatedHealthCheck": true
+        "IncludeInAutomatedHealthCheck": true,
+        "AdditionalSuccessStatuses": [ 405 ]
       },
       "IPAFFS_PreProd_Soap_Search": {
         "Method": "GET",


### PR DESCRIPTION
Health check against an external HMRC route is showing as Degraded because we are receiving HTTP Status 405 back from the test.
This should be considered successful because the GET request was specifically configured so as not to cause issues on HMRC.
This change allows for configuration to control certain Status codes being considered as successful on a per route definition basis.