### PR TITLE
CDMS-660: adds instance Id to the metrics dimensions

### DIFF
--- a/BtmsGateway.Test/Services/Metrics/HealthMetricsTests.cs
+++ b/BtmsGateway.Test/Services/Metrics/HealthMetricsTests.cs
@@ -60,23 +60,27 @@ public class HealthMetricsTests : MetricsTestBase
             .Tags[MetricsConstants.HealthTags.Description]
             .Should()
             .Be("Overall health of the BTMS Gateway");
+        healthMeasurements[0].ContainsTags(MetricsConstants.HealthTags.InstanceId).Should().BeTrue();
 
         healthMeasurements[1].Value.Should().Be(0);
         healthMeasurements[1].ContainsTags(MetricsConstants.HealthTags.Component).Should().BeTrue();
         healthMeasurements[1].Tags[MetricsConstants.HealthTags.Component].Should().Be("BTMS Gateway Dependency 1");
         healthMeasurements[1].Tags[MetricsConstants.HealthTags.Description].Should().Be("Health report 1");
+        healthMeasurements[1].ContainsTags(MetricsConstants.HealthTags.InstanceId).Should().BeTrue();
         healthMeasurements[1].Tags["topic-arn"].Should().Be("aws_acc:some_topic.fifo");
 
         healthMeasurements[2].Value.Should().Be(1);
         healthMeasurements[2].ContainsTags(MetricsConstants.HealthTags.Component).Should().BeTrue();
         healthMeasurements[2].Tags[MetricsConstants.HealthTags.Component].Should().Be("BTMS Gateway Dependency 2");
         healthMeasurements[2].Tags[MetricsConstants.HealthTags.Description].Should().Be("Health report 2");
+        healthMeasurements[2].ContainsTags(MetricsConstants.HealthTags.InstanceId).Should().BeTrue();
         healthMeasurements[2].Tags["queue"].Should().Be("some_queue");
 
         healthMeasurements[3].Value.Should().Be(2);
         healthMeasurements[3].ContainsTags(MetricsConstants.HealthTags.Component).Should().BeTrue();
         healthMeasurements[3].Tags[MetricsConstants.HealthTags.Component].Should().Be("BTMS Gateway Dependency 3");
         healthMeasurements[3].Tags[MetricsConstants.HealthTags.Description].Should().Be("Health report 3");
+        healthMeasurements[3].ContainsTags(MetricsConstants.HealthTags.InstanceId).Should().BeTrue();
         healthMeasurements[3].Tags["api"].Should().Be("some_api");
     }
 }

--- a/BtmsGateway/Services/Metrics/HealthMetrics.cs
+++ b/BtmsGateway/Services/Metrics/HealthMetrics.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Amazon.CloudWatch.EMF.Model;
+using Amazon.Util;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace BtmsGateway.Services.Metrics;
@@ -12,6 +13,7 @@ public interface IHealthMetrics
 
 public class HealthMetrics : IHealthMetrics
 {
+    private readonly string? instanceId = EC2InstanceMetadata.InstanceId;
     private readonly Gauge<int> health;
 
     public HealthMetrics(IMeterFactory meterFactory)
@@ -27,21 +29,22 @@ public class HealthMetrics : IHealthMetrics
 
     public void ReportHealth(HealthReport report)
     {
-        health.Record((int)report.Status, BuildOverallTags());
+        health.Record((int)report.Status, BuildOverallTags(instanceId));
 
         foreach (var healthReportEntry in report.Entries)
         {
-            health.Record((int)healthReportEntry.Value.Status, BuildComponentTags(healthReportEntry));
+            health.Record((int)healthReportEntry.Value.Status, BuildComponentTags(healthReportEntry, instanceId));
         }
     }
 
-    private static TagList BuildComponentTags(KeyValuePair<string, HealthReportEntry> reportEntry)
+    private static TagList BuildComponentTags(KeyValuePair<string, HealthReportEntry> reportEntry, string? instanceId)
     {
         var tags = new TagList
         {
             { MetricsConstants.HealthTags.Service, Process.GetCurrentProcess().ProcessName },
             { MetricsConstants.HealthTags.Component, reportEntry.Key },
             { MetricsConstants.HealthTags.Description, reportEntry.Value.Description },
+            { MetricsConstants.HealthTags.InstanceId, instanceId },
         };
 
         foreach (var keyValuePair in reportEntry.Value.Data)
@@ -52,13 +55,14 @@ public class HealthMetrics : IHealthMetrics
         return tags;
     }
 
-    private static TagList BuildOverallTags()
+    private static TagList BuildOverallTags(string? instanceId)
     {
         return new TagList
         {
             { MetricsConstants.HealthTags.Service, Process.GetCurrentProcess().ProcessName },
             { MetricsConstants.HealthTags.Component, "BTMS Gateway" },
             { MetricsConstants.HealthTags.Description, "Overall health of the BTMS Gateway" },
+            { MetricsConstants.HealthTags.InstanceId, instanceId },
         };
     }
 }

--- a/BtmsGateway/Services/Metrics/MetricsConstants.cs
+++ b/BtmsGateway/Services/Metrics/MetricsConstants.cs
@@ -31,6 +31,7 @@ public static class MetricsConstants
         public const string Service = "ServiceName";
         public const string Component = "Component";
         public const string Description = "Description";
+        public const string InstanceId = "InstanceId";
     }
 
     public static class InstrumentNames


### PR DESCRIPTION
- adds instance id to the Health metrics for use in building Grafana Dashboards that cover all deployed instances

Playing around with metrics dimensions, so this may or may not get reverted depending on whether this function is available on the CDP platform and how useful it is in Grafana.
May have to revert to calling the Metadata endpoint in order to get the TaskARN instead.