### PR TITLE
CDMS-660: adds instance Id to the metrics dimensions

### DIFF
--- a/BtmsGateway.Test/BtmsGateway.Test.csproj
+++ b/BtmsGateway.Test/BtmsGateway.Test.csproj
@@ -64,5 +64,8 @@
     <None Update="Middleware\Fixtures\CdsErrorHandling.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Services\Routing\Fixtures\EcsMetadata.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/BtmsGateway.Test/Services/Metrics/HealthMetricsTests.cs
+++ b/BtmsGateway.Test/Services/Metrics/HealthMetricsTests.cs
@@ -60,23 +60,27 @@ public class HealthMetricsTests : MetricsTestBase
             .Tags[MetricsConstants.HealthTags.Description]
             .Should()
             .Be("Overall health of the BTMS Gateway");
+        healthMeasurements[0].ContainsTags(MetricsConstants.HealthTags.InstanceId).Should().BeTrue();
 
         healthMeasurements[1].Value.Should().Be(0);
         healthMeasurements[1].ContainsTags(MetricsConstants.HealthTags.Component).Should().BeTrue();
         healthMeasurements[1].Tags[MetricsConstants.HealthTags.Component].Should().Be("BTMS Gateway Dependency 1");
         healthMeasurements[1].Tags[MetricsConstants.HealthTags.Description].Should().Be("Health report 1");
+        healthMeasurements[1].ContainsTags(MetricsConstants.HealthTags.InstanceId).Should().BeTrue();
         healthMeasurements[1].Tags["topic-arn"].Should().Be("aws_acc:some_topic.fifo");
 
         healthMeasurements[2].Value.Should().Be(1);
         healthMeasurements[2].ContainsTags(MetricsConstants.HealthTags.Component).Should().BeTrue();
         healthMeasurements[2].Tags[MetricsConstants.HealthTags.Component].Should().Be("BTMS Gateway Dependency 2");
         healthMeasurements[2].Tags[MetricsConstants.HealthTags.Description].Should().Be("Health report 2");
+        healthMeasurements[2].ContainsTags(MetricsConstants.HealthTags.InstanceId).Should().BeTrue();
         healthMeasurements[2].Tags["queue"].Should().Be("some_queue");
 
         healthMeasurements[3].Value.Should().Be(2);
         healthMeasurements[3].ContainsTags(MetricsConstants.HealthTags.Component).Should().BeTrue();
         healthMeasurements[3].Tags[MetricsConstants.HealthTags.Component].Should().Be("BTMS Gateway Dependency 3");
         healthMeasurements[3].Tags[MetricsConstants.HealthTags.Description].Should().Be("Health report 3");
+        healthMeasurements[3].ContainsTags(MetricsConstants.HealthTags.InstanceId).Should().BeTrue();
         healthMeasurements[3].Tags["api"].Should().Be("some_api");
     }
 }

--- a/BtmsGateway.Test/Services/Metrics/InstanceMetadataTests.cs
+++ b/BtmsGateway.Test/Services/Metrics/InstanceMetadataTests.cs
@@ -1,0 +1,62 @@
+using BtmsGateway.Domain;
+using BtmsGateway.Services.Metrics;
+using BtmsGateway.Services.Routing;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NSubstitute.ReturnsExtensions;
+
+namespace BtmsGateway.Test.Services.Metrics;
+
+public class InstanceMetadataTests
+{
+    [Fact]
+    public async Task When_init_Then_should_set_instance_id()
+    {
+        var logger = Substitute.For<ILogger<InstanceMetadataTests>>();
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(logger);
+
+        var apiSender = Substitute.For<IApiSender>();
+        apiSender
+            .GetEcsMetadataAsync(Arg.Any<CancellationToken>())
+            .Returns(new EcsMetadata { TaskArn = "aws_account_arn/TestId" });
+
+        await InstanceMetadata.InitAsync(apiSender, loggerFactory);
+
+        InstanceMetadata.InstanceId.Should().Be("TestId");
+    }
+
+    [Fact]
+    public async Task When_init_and_ecs_metadata_is_null_Then_should_set_instance_id_to_guid()
+    {
+        var logger = Substitute.For<ILogger<InstanceMetadataTests>>();
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(logger);
+
+        var apiSender = Substitute.For<IApiSender>();
+        apiSender.GetEcsMetadataAsync(Arg.Any<CancellationToken>()).ReturnsNull();
+
+        await InstanceMetadata.InitAsync(apiSender, loggerFactory);
+
+        InstanceMetadata.InstanceId.Should().NotBeNullOrEmpty();
+        Guid.TryParse(InstanceMetadata.InstanceId, out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task When_init_and_exception_occurs_Then_should_set_instance_id_to_guid()
+    {
+        var logger = Substitute.For<ILogger<InstanceMetadataTests>>();
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(logger);
+
+        var apiSender = Substitute.For<IApiSender>();
+        apiSender.GetEcsMetadataAsync(Arg.Any<CancellationToken>()).ThrowsAsync<Exception>();
+
+        await InstanceMetadata.InitAsync(apiSender, loggerFactory);
+
+        InstanceMetadata.InstanceId.Should().NotBeNullOrEmpty();
+        Guid.TryParse(InstanceMetadata.InstanceId, out _).Should().BeTrue();
+    }
+}

--- a/BtmsGateway.Test/Services/Routing/ApiSenderTests.cs
+++ b/BtmsGateway.Test/Services/Routing/ApiSenderTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Reflection;
+using System.Text.Json;
 using BtmsGateway.Services.Routing;
 using FluentAssertions;
 using Microsoft.AspNetCore.HeaderPropagation;
@@ -130,6 +131,51 @@ public class ApiSenderTests
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
+    [Fact]
+    public async Task When_get_ecs_metadata_Then_should_return_response()
+    {
+        Environment.SetEnvironmentVariable("ECS_CONTAINER_METADATA_URI_V4", "http://test-url");
+
+        var json = await File.ReadAllTextAsync(
+            Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Services", "Routing", "Fixtures", "EcsMetadata.json")
+        );
+        var content = new StringContent(json);
+
+        var mocks = CreateMocks(content: content);
+        var sut = new ApiSender(mocks.Factory, mocks.ServiceProvider, mocks.Configuration);
+
+        var response = await sut.GetEcsMetadataAsync(CancellationToken.None);
+
+        response.Should().NotBeNull();
+        response
+            ?.TaskArn.Should()
+            .Be("arn:aws:ecs:eu-west-2:000000000000:task/dev-ecs-protected/f80c7eb5655547849cda89e80aa0eef8");
+    }
+
+    [Fact]
+    public async Task When_get_ecs_metadata_and_metadata_uri_is_not_present_Then_should_return_null()
+    {
+        Environment.SetEnvironmentVariable("ECS_CONTAINER_METADATA_URI_V4", null);
+
+        var mocks = CreateMocks();
+        var sut = new ApiSender(mocks.Factory, mocks.ServiceProvider, mocks.Configuration);
+
+        var response = await sut.GetEcsMetadataAsync(CancellationToken.None);
+
+        response.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task When_get_ecs_metadata_and_metadata_uri_returns_null_Then_should_throw()
+    {
+        Environment.SetEnvironmentVariable("ECS_CONTAINER_METADATA_URI_V4", "http://test-url");
+
+        var mocks = CreateMocks();
+        var sut = new ApiSender(mocks.Factory, mocks.ServiceProvider, mocks.Configuration);
+
+        await Assert.ThrowsAsync<JsonException>(() => sut.GetEcsMetadataAsync(CancellationToken.None));
+    }
+
     private static (
         HttpClientHandler Handler,
         IHttpClientFactory Factory,
@@ -137,9 +183,11 @@ public class ApiSenderTests
         IServiceProvider ServiceProvider,
         IConfiguration Configuration,
         HeaderPropagationValues HeaderPropagationValues
-    ) CreateMocks(HttpStatusCode statusCode = HttpStatusCode.OK)
+    ) CreateMocks(HttpStatusCode statusCode = HttpStatusCode.OK, HttpContent content = null)
     {
         var response = new HttpResponseMessage(statusCode);
+        if (content is not null)
+            response.Content = content;
 
         var handler = Substitute.ForPartsOf<HttpClientHandler>();
         handler

--- a/BtmsGateway.Test/Services/Routing/Fixtures/EcsMetadata.json
+++ b/BtmsGateway.Test/Services/Routing/Fixtures/EcsMetadata.json
@@ -1,0 +1,13 @@
+{
+  "Cluster": "FOO",
+  "TaskARN": "arn:aws:ecs:eu-west-2:000000000000:task/dev-ecs-protected/f80c7eb5655547849cda89e80aa0eef8",
+  "Family": "FOO",
+  "Revision": "FOO",
+  "DesiredStatus": "RUNNING",
+  "KnownStatus": "RUNNING",
+  "Limits":
+  {
+    "CPU": 0.5,
+    "Memory": 1024
+  }
+}

--- a/BtmsGateway/Domain/EcsMetadata.cs
+++ b/BtmsGateway/Domain/EcsMetadata.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace BtmsGateway.Domain;
+
+public class EcsMetadata
+{
+    [property: JsonPropertyName("TaskARN")]
+    public string? TaskArn { get; set; }
+}

--- a/BtmsGateway/Extensions/ApplicationBuilderExtensions.cs
+++ b/BtmsGateway/Extensions/ApplicationBuilderExtensions.cs
@@ -1,0 +1,17 @@
+using System.Diagnostics.CodeAnalysis;
+using BtmsGateway.Services.Metrics;
+using BtmsGateway.Services.Routing;
+
+namespace BtmsGateway.Extensions;
+
+[ExcludeFromCodeCoverage]
+public static class ApplicationBuilderExtensions
+{
+    public static async Task InitializeAsync(this IApplicationBuilder builder)
+    {
+        await InstanceMetadata.InitAsync(
+            builder.ApplicationServices.GetRequiredService<IApiSender>(),
+            builder.ApplicationServices.GetRequiredService<ILoggerFactory>()
+        );
+    }
+}

--- a/BtmsGateway/Program.cs
+++ b/BtmsGateway/Program.cs
@@ -17,6 +17,7 @@ using Serilog.Core;
 using Environment = System.Environment;
 
 var app = CreateWebApplication(args);
+await app.InitializeAsync();
 await app.RunAsync();
 
 [ExcludeFromCodeCoverage]

--- a/BtmsGateway/Services/Metrics/HealthMetrics.cs
+++ b/BtmsGateway/Services/Metrics/HealthMetrics.cs
@@ -42,6 +42,7 @@ public class HealthMetrics : IHealthMetrics
             { MetricsConstants.HealthTags.Service, Process.GetCurrentProcess().ProcessName },
             { MetricsConstants.HealthTags.Component, reportEntry.Key },
             { MetricsConstants.HealthTags.Description, reportEntry.Value.Description },
+            { MetricsConstants.HealthTags.InstanceId, InstanceMetadata.InstanceId },
         };
 
         foreach (var keyValuePair in reportEntry.Value.Data)
@@ -59,6 +60,7 @@ public class HealthMetrics : IHealthMetrics
             { MetricsConstants.HealthTags.Service, Process.GetCurrentProcess().ProcessName },
             { MetricsConstants.HealthTags.Component, "BTMS Gateway" },
             { MetricsConstants.HealthTags.Description, "Overall health of the BTMS Gateway" },
+            { MetricsConstants.HealthTags.InstanceId, InstanceMetadata.InstanceId },
         };
     }
 }

--- a/BtmsGateway/Services/Metrics/InstanceMetadata.cs
+++ b/BtmsGateway/Services/Metrics/InstanceMetadata.cs
@@ -1,0 +1,31 @@
+using BtmsGateway.Services.Routing;
+
+namespace BtmsGateway.Services.Metrics;
+
+public static class InstanceMetadata
+{
+    private static ILogger _logger = null!;
+
+    public static string? InstanceId { get; private set; }
+
+    public static async Task InitAsync(IApiSender apiSender, ILoggerFactory loggerFactory)
+    {
+        try
+        {
+            _logger = loggerFactory.CreateLogger(nameof(InstanceMetadata));
+
+            var ecsMetadata = await apiSender.GetEcsMetadataAsync(CancellationToken.None);
+
+            var taskArnParts = ecsMetadata?.TaskArn?.Split('/');
+            InstanceId = taskArnParts?[^1] ?? Guid.NewGuid().ToString();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Unable to retrieve ECS instance metadata. Configuring instance ID with GUID instead."
+            );
+            InstanceId = Guid.NewGuid().ToString();
+        }
+    }
+}

--- a/BtmsGateway/Services/Metrics/MetricsConstants.cs
+++ b/BtmsGateway/Services/Metrics/MetricsConstants.cs
@@ -31,6 +31,7 @@ public static class MetricsConstants
         public const string Service = "ServiceName";
         public const string Component = "Component";
         public const string Description = "Description";
+        public const string InstanceId = "InstanceId";
     }
 
     public static class InstrumentNames


### PR DESCRIPTION
- uses ECS metadata to assign an instance id, based on the unique TaskARN if available, otherwise assigns a new guid. For use in creating Grafana dashboards that are relevant to the number of deployed instances.