### PR TITLE
CDMS-684: removes redundant configuration and health checks

### DIFF
--- a/BtmsGateway/Services/Health/ConfigureHealthChecks.cs
+++ b/BtmsGateway/Services/Health/ConfigureHealthChecks.cs
@@ -63,7 +63,11 @@ public static class ConfigureHealthChecks
         if (routingConfig == null || routingConfig.AutomatedHealthCheckDisabled)
             return builder;
 
-        foreach (var queues in routingConfig.NamedLinks.Where(x => x.Value.LinkType == LinkType.Queue))
+        foreach (
+            var queues in routingConfig.NamedLinks.Where(x =>
+                x.Value.LinkType == LinkType.Queue && x.Key != "AlvsErrorQueue" // To be removed as part of CDMS-616
+            )
+        )
         {
             builder.AddTypeActivatedCheck<TopicHealthCheck>(
                 queues.Key,

--- a/BtmsGateway/appsettings.json
+++ b/BtmsGateway/appsettings.json
@@ -139,22 +139,6 @@
         "LinkType": "Url",
         "Link": "http://btms-gateway-stub.localtest.me:3092/forked"
       },
-      "CustomsClearanceRequestQueue": {
-        "LinkType": "Queue",
-        "Link": "arn:aws:sns:eu-west-2:000000000000:customs_clearance_request.fifo"
-      },
-      "CustomsFinalisationQueue": {
-        "LinkType": "Queue",
-        "Link": "arn:aws:sns:eu-west-2:000000000000:customs_finalisation_notification.fifo"
-      },
-      "CustomsErrorQueue": {
-        "LinkType": "Queue",
-        "Link": "arn:aws:sns:eu-west-2:000000000000:customs_error_notification.fifo"
-      },
-      "AlvsDecisionQueue": {
-        "LinkType": "Queue",
-        "Link": "arn:aws:sns:eu-west-2:000000000000:alvs_decision_notification.fifo"
-      },
       "AlvsErrorQueue": {
         "LinkType": "Queue",
         "Link": "arn:aws:sns:eu-west-2:000000000000:alvs_error_notification.fifo"


### PR DESCRIPTION
Removes redundant configuration used in previous integration with BTMS Backend and also removes them from the Health Checks.