### PR TITLE
Defaults correlation id on SOAP messages created from BTMS Clearance Decisions.

### DIFF
--- a/BtmsGateway.Test/Services/Converter/Fixtures/ClearanceDecisionSoap.xml
+++ b/BtmsGateway.Test/Services/Converter/Fixtures/ClearanceDecisionSoap.xml
@@ -14,8 +14,8 @@
         <ServiceHeader>
           <SourceSystem>ALVS</SourceSystem>
           <DestinationSystem>CDS</DestinationSystem>
-          <CorrelationId>external-correlation-id</CorrelationId>
-          <ServiceCallTimestamp>2025-01-01T00:00:00.00</ServiceCallTimestamp>
+          <CorrelationId>000</CorrelationId>
+          <ServiceCallTimestamp>2025-01-01T00:00:00.000</ServiceCallTimestamp>
         </ServiceHeader>
         <Header>
           <EntryReference>MRN123</EntryReference>

--- a/BtmsGateway/Services/Converter/ClearanceDecisionToSoapConverter.cs
+++ b/BtmsGateway/Services/Converter/ClearanceDecisionToSoapConverter.cs
@@ -14,8 +14,8 @@ public static class ClearanceDecisionToSoapConverter
                 "ServiceHeader",
                 new XElement("SourceSystem", "ALVS"),
                 new XElement("DestinationSystem", "CDS"),
-                new XElement("CorrelationId", clearanceDecision.ExternalCorrelationId),
-                new XElement("ServiceCallTimestamp", clearanceDecision.Timestamp.ToString("yyyy-MM-ddTHH:mm:ss.sss"))
+                new XElement("CorrelationId", "000"),
+                new XElement("ServiceCallTimestamp", clearanceDecision.Timestamp.ToString("yyyy-MM-ddTHH:mm:ss.fff"))
             ),
             new XElement(
                 "Header",


### PR DESCRIPTION
- Decision Notifications created from BTMS Clearance Decisions have a default "000" correlation id
- Fixes an error in the timestamp format to include milliseconds