### PR TITLE
CDMS-660: adds some logging to help identify issue in Test environment.

### DIFF
--- a/BtmsGateway.Test/Services/Metrics/MetricsTestBase.cs
+++ b/BtmsGateway.Test/Services/Metrics/MetricsTestBase.cs
@@ -2,6 +2,8 @@ using System.Diagnostics.Metrics;
 using BtmsGateway.Services.Metrics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using NSubstitute;
+using Serilog;
 
 namespace BtmsGateway.Test.Services.Metrics;
 
@@ -23,6 +25,7 @@ public abstract class MetricsTestBase
         serviceCollection.AddSingleton<IRequestMetrics, RequestMetrics>();
         serviceCollection.AddSingleton<IConsumerMetrics, ConsumerMetrics>();
         serviceCollection.AddSingleton<IHealthMetrics, HealthMetrics>();
+        serviceCollection.AddSingleton(Substitute.For<ILogger>());
         return serviceCollection.BuildServiceProvider();
     }
 


### PR DESCRIPTION
- Adds some logging around the publishing of health metrics to aid in identifying where in the process that is failing to surface metrics in Grafana for one of the Panels.

The Information log will likely be removed, once we have identified the issue, to avoid noise in our logs.