### PR TITLE
CDMS-660: remove content dimension to test panel fix

### DIFF
--- a/BtmsGateway.Test/Services/Metrics/HealthMetricsTests.cs
+++ b/BtmsGateway.Test/Services/Metrics/HealthMetricsTests.cs
@@ -25,7 +25,11 @@ public class HealthMetricsTests : MetricsTestBase
                     description: "Health report 1",
                     TimeSpan.Zero,
                     null,
-                    new Dictionary<string, object> { { "topic-arn", "aws_acc:some_topic.fifo" } }
+                    new Dictionary<string, object>
+                    {
+                        { "topic-arn", "aws_acc:some_topic.fifo" },
+                        { "content", "some content" }
+                    }
                 )
             },
             {
@@ -58,6 +62,7 @@ public class HealthMetricsTests : MetricsTestBase
         healthMeasurements.Count.Should().Be(4);
         healthMeasurements[0].Value.Should().Be(1);
         healthMeasurements[0].ContainsTags(MetricsConstants.HealthTags.Component).Should().BeTrue();
+        healthMeasurements[0].ContainsTags("content").Should().BeFalse();
         healthMeasurements[0].Tags[MetricsConstants.HealthTags.Component].Should().Be("BTMS Gateway");
         healthMeasurements[0]
             .Tags[MetricsConstants.HealthTags.Description]

--- a/BtmsGateway.Test/Services/Metrics/HealthMetricsTests.cs
+++ b/BtmsGateway.Test/Services/Metrics/HealthMetricsTests.cs
@@ -28,7 +28,7 @@ public class HealthMetricsTests : MetricsTestBase
                     new Dictionary<string, object>
                     {
                         { "topic-arn", "aws_acc:some_topic.fifo" },
-                        { "content", "some content" }
+                        { "content", "some content" },
                     }
                 )
             },

--- a/BtmsGateway/Services/Metrics/HealthMetrics.cs
+++ b/BtmsGateway/Services/Metrics/HealthMetrics.cs
@@ -68,7 +68,11 @@ public class HealthMetrics : IHealthMetrics
             { MetricsConstants.HealthTags.Description, reportEntry.Value.Description },
         };
 
-        foreach (var keyValuePair in reportEntry.Value.Data)
+        foreach (
+            var keyValuePair in reportEntry.Value.Data.Where(kvp =>
+                !string.Equals(kvp.Key, "content", StringComparison.InvariantCultureIgnoreCase)
+            )
+        )
         {
             tags.Add(keyValuePair.Key, keyValuePair.Value);
         }


### PR DESCRIPTION
- Theory test to try fixing one Panel in Grafana that isn't receiving metrics. All Panels work in the Dev environment. In Test, there is one Panel that doesn't appear to be receiving data. Confirmed the same service code is deployed and CDP Support have checked the Panel code as well as the Cloudwatch Metrics. The broken Panel does have different content dimension in Test so testing whether removing this has any effect. The dimension is not currently used in the Panels anyway.