### PR TITLE
CDMS-744: removes the PreProd suffix from the health checks.

### DIFF
--- a/BtmsGateway/appsettings.json
+++ b/BtmsGateway/appsettings.json
@@ -209,27 +209,22 @@
         "Method": "GET",
         "Url": "http://btms-gateway-stub.localtest.me:3092/health"
       },
-      "IBM_ALVS_PreProd": {
+      "IBM_ALVS": {
         "Method": "GET",
-        "Url": "https://10.62.146.246/ITSW/CDS/ALVSCDSErrorNotificationService",
+        "Url": "http://btms-gateway-stub.localtest.me:3092/health",
         "HostHeader": "t2.secure.services.defra.gsi.gov.uk",
         "IncludeInAutomatedHealthCheck": true
       },
-      "HMRC_CDS_PreProd": {
+      "HMRC_CDS": {
         "Method": "GET",
-        "Url": "https://10.102.9.31/ws/CDS/defra/alvsclearanceinbound/v1",
+        "Url": "http://btms-gateway-stub.localtest.me:3092/health",
         "HostHeader": "syst32.hmrc.gov.uk",
         "IncludeInAutomatedHealthCheck": true,
         "AdditionalSuccessStatuses": [ 405 ]
       },
-      "IPAFFS_PreProd_Soap_Search": {
+      "IPAFFS_Soap_Search": {
         "Method": "GET",
-        "Url": "https://importnotification-api-pre.azure.defra.cloud/soapsearch/pre/admin/health-check",
-        "IncludeInAutomatedHealthCheck": true
-      },
-      "IPAFFS_Test_Soap_Search": {
-        "Method": "GET",
-        "Url": "https://importnotification-api-tst.azure.defra.cloud/soapsearch/tst/admin/health-check",
+        "Url": "http://btms-gateway-stub.localtest.me:3092/health",
         "IncludeInAutomatedHealthCheck": true
       }
     }


### PR DESCRIPTION
- Removes the PreProd suffix from the health checks. This allows us to configure each environment to check against a relevant URL and configure our Grafana Dashboards so they are more generic and make more sense for each environment.
- Does a single check against the relevant IPAFFs environment.
- Defaults to a stub check for non-connected environments so health checks don't fail. Configuration in cdp-app-config will be used per environment and point to external URLs where connectivity is expected to be available.