### PR TITLE
CDMS-744: removes the host header config for stubbed health checks

### DIFF
--- a/BtmsGateway/appsettings.json
+++ b/BtmsGateway/appsettings.json
@@ -212,13 +212,11 @@
       "IBM_ALVS": {
         "Method": "GET",
         "Url": "http://btms-gateway-stub.localtest.me:3092/health",
-        "HostHeader": "t2.secure.services.defra.gsi.gov.uk",
         "IncludeInAutomatedHealthCheck": true
       },
       "HMRC_CDS": {
         "Method": "GET",
         "Url": "http://btms-gateway-stub.localtest.me:3092/health",
-        "HostHeader": "syst32.hmrc.gov.uk",
         "IncludeInAutomatedHealthCheck": true,
         "AdditionalSuccessStatuses": [ 405 ]
       },


### PR DESCRIPTION
- Default appsettings uses Stub health checks which don't require the host header configuration. These will be specified in the relevant cdp-app-config environment configuration.