### PR TITLE
Disables health checking of the BTMS Backend components during Connected Silent Running

### DIFF
--- a/BtmsGateway/Services/Health/ConfigureHealthChecks.cs
+++ b/BtmsGateway/Services/Health/ConfigureHealthChecks.cs
@@ -63,7 +63,16 @@ public static class ConfigureHealthChecks
         if (routingConfig == null || routingConfig.AutomatedHealthCheckDisabled)
             return builder;
 
-        foreach (var queues in routingConfig.NamedLinks.Where(x => x.Value.LinkType == LinkType.Queue))
+        foreach (
+            var queues in routingConfig.NamedLinks.Where(x =>
+                x.Value.LinkType == LinkType.Queue
+                && !string.Equals(
+                    x.Key,
+                    "InboundCustomsDeclarationReceivedTopic",
+                    StringComparison.InvariantCultureIgnoreCase
+                )
+            )
+        )
         {
             builder.AddTypeActivatedCheck<TopicHealthCheck>(
                 queues.Key,
@@ -84,11 +93,11 @@ public static class ConfigureHealthChecks
         if (awsSqsOptions is null || string.IsNullOrEmpty(awsSqsOptions.OutboundClearanceDecisionsQueueName))
             return builder;
 
-        builder.AddTypeActivatedCheck<QueueHealthCheck>(
-            "OutboundClearanceDecisionsQueue",
-            failureStatus: HealthStatus.Unhealthy,
-            args: ["OutboundClearanceDecisionsQueue", awsSqsOptions.OutboundClearanceDecisionsQueueName, configuration]
-        );
+        // builder.AddTypeActivatedCheck<QueueHealthCheck>(
+        //     "OutboundClearanceDecisionsQueue",
+        //     failureStatus: HealthStatus.Unhealthy,
+        //     args: ["OutboundClearanceDecisionsQueue", awsSqsOptions.OutboundClearanceDecisionsQueueName, configuration]
+        // );
 
         return builder;
     }
@@ -101,20 +110,20 @@ public static class ConfigureHealthChecks
     {
         if (dataApiOptions is not null && !string.IsNullOrEmpty(dataApiOptions.BaseAddress))
         {
-            builder.AddTypeActivatedCheck<ApiHealthCheck<DataApiOptions>>(
-                "TradeImportsDataApi",
-                failureStatus: HealthStatus.Unhealthy,
-                args: ["TradeImportsDataApi", "/health/authorized", dataApiOptions]
-            );
+            // builder.AddTypeActivatedCheck<ApiHealthCheck<DataApiOptions>>(
+            //     "TradeImportsDataApi",
+            //     failureStatus: HealthStatus.Unhealthy,
+            //     args: ["TradeImportsDataApi", "/health/authorized", dataApiOptions]
+            // );
         }
 
         if (decisionComparerApiOptions is not null && !string.IsNullOrEmpty(decisionComparerApiOptions.BaseAddress))
         {
-            builder.AddTypeActivatedCheck<ApiHealthCheck<DecisionComparerApiOptions>>(
-                "TradeImportsDecisionComparerApi",
-                failureStatus: HealthStatus.Unhealthy,
-                args: ["DecisionComparerApi", "/health/authorized", decisionComparerApiOptions]
-            );
+            // builder.AddTypeActivatedCheck<ApiHealthCheck<DecisionComparerApiOptions>>(
+            //     "TradeImportsDecisionComparerApi",
+            //     failureStatus: HealthStatus.Unhealthy,
+            //     args: ["DecisionComparerApi", "/health/authorized", decisionComparerApiOptions]
+            // );
         }
 
         return builder;


### PR DESCRIPTION
- For connected silent running, we will not be able to run the BTMS Backend. As such, the Gateway needs to disable health checks against these dependent components until they are required at a later date.