### PR TITLE
Map and include ResourceId header to EntryReference

### DIFF
--- a/BtmsGateway/Domain/MessagingConstants.cs
+++ b/BtmsGateway/Domain/MessagingConstants.cs
@@ -6,6 +6,7 @@ public static class MessagingConstants
     {
         public const string CorrelationId = "CorrelationId";
         public const string InboundHmrcMessageType = "InboundHmrcMessageType";
+        public const string ResourceId = "ResourceId";
     }
 
     public static class MessageTypes

--- a/BtmsGateway/Middleware/MessageData.cs
+++ b/BtmsGateway/Middleware/MessageData.cs
@@ -175,6 +175,11 @@ public class MessageData
             },
         };
 
+        messageAttributes.Add(
+            MessagingConstants.MessageAttributeKeys.ResourceId,
+            new MessageAttributeValue { DataType = "String", StringValue = ContentMap.EntryReference }
+        );
+
         var attributeValue = messageSubXPath switch
         {
             MessagingConstants.SoapMessageTypes.ALVSClearanceRequest => MessagingConstants


### PR DESCRIPTION
To be able to include generic logging around message consumption within the BTMS pipeline, this PR includes the EntryReference as a ResourceId header, which downstream services can then use.