### PR TITLE
Remove logger during startup

### DIFF
--- a/BtmsGateway.Test/Http/ProxyTest.cs
+++ b/BtmsGateway.Test/Http/ProxyTest.cs
@@ -18,7 +18,7 @@ public class ProxyTest
     {
         var proxy = new System.Net.WebProxy { BypassProxyOnLocal = true };
 
-        Proxy.ConfigureProxy(proxy, ProxyUri, _logger);
+        Proxy.ConfigureProxy(proxy, ProxyUri);
 
         var credentials = proxy.Credentials?.GetCredential(new Uri(ProxyUri), "Basic");
 
@@ -33,7 +33,7 @@ public class ProxyTest
 
         var proxy = new System.Net.WebProxy { BypassProxyOnLocal = true };
 
-        Proxy.ConfigureProxy(proxy, noPasswordUri, _logger);
+        Proxy.ConfigureProxy(proxy, noPasswordUri);
 
         proxy.Credentials.Should().BeNull();
     }
@@ -43,7 +43,7 @@ public class ProxyTest
     {
         var proxy = new System.Net.WebProxy { BypassProxyOnLocal = true };
 
-        Proxy.ConfigureProxy(proxy, ProxyUri, _logger);
+        Proxy.ConfigureProxy(proxy, ProxyUri);
         proxy.Address.Should().NotBeNull();
         proxy.Address?.AbsoluteUri.Should().Be(LocalProxy);
     }
@@ -51,7 +51,7 @@ public class ProxyTest
     [Fact]
     public void CreateProxyFromUri()
     {
-        var proxy = Proxy.CreateProxy(ProxyUri, _logger);
+        var proxy = Proxy.CreateProxy(ProxyUri);
 
         proxy.Address.Should().NotBeNull();
         proxy.Address?.AbsoluteUri.Should().Be(LocalProxy);
@@ -60,7 +60,7 @@ public class ProxyTest
     [Fact]
     public void CreateNoProxyFromEmptyUri()
     {
-        var proxy = Proxy.CreateProxy(null, _logger);
+        var proxy = Proxy.CreateProxy(null);
 
         proxy.Address.Should().BeNull();
     }
@@ -68,7 +68,7 @@ public class ProxyTest
     [Fact]
     public void ProxyShouldBypassLocal()
     {
-        var proxy = Proxy.CreateProxy(ProxyUri, _logger);
+        var proxy = Proxy.CreateProxy(ProxyUri);
 
         proxy.BypassProxyOnLocal.Should().BeTrue();
         proxy.IsBypassed(new Uri(Localhost)).Should().BeTrue();
@@ -78,7 +78,7 @@ public class ProxyTest
     [Fact]
     public void HandlerShouldHaveProxy()
     {
-        var handler = Proxy.CreateHttpClientHandler(ProxyUri, _logger);
+        var handler = Proxy.CreateHttpClientHandler(ProxyUri);
 
         handler.Proxy.Should().NotBeNull();
         handler.UseProxy.Should().BeTrue();

--- a/BtmsGateway.Test/TestUtils/TestWebServer.cs
+++ b/BtmsGateway.Test/TestUtils/TestWebServer.cs
@@ -11,6 +11,8 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using NSubstitute;
+using Serilog;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
 
@@ -45,7 +47,7 @@ public class TestWebServer : IDisposable
         builder.ConfigureToType<RoutingConfig>();
         builder.ConfigureToType<HealthCheckConfig>();
         builder.WebHost.UseUrls(url);
-        builder.AddServices(integrationTest: true);
+        builder.AddServices(Substitute.For<ILogger>());
         foreach (var testService in testServices)
             builder.Services.Replace(testService);
         builder.Services.AddHealthChecks();

--- a/BtmsGateway.Test/TestUtils/TestWebServer.cs
+++ b/BtmsGateway.Test/TestUtils/TestWebServer.cs
@@ -45,7 +45,7 @@ public class TestWebServer : IDisposable
         builder.ConfigureToType<RoutingConfig>();
         builder.ConfigureToType<HealthCheckConfig>();
         builder.WebHost.UseUrls(url);
-        builder.AddServices();
+        builder.AddServices(integrationTest: true);
         foreach (var testService in testServices)
             builder.Services.Replace(testService);
         builder.Services.AddHealthChecks();

--- a/BtmsGateway.Test/TestUtils/TestWebServer.cs
+++ b/BtmsGateway.Test/TestUtils/TestWebServer.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using NSubstitute;
 
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
 
@@ -46,7 +45,7 @@ public class TestWebServer : IDisposable
         builder.ConfigureToType<RoutingConfig>();
         builder.ConfigureToType<HealthCheckConfig>();
         builder.WebHost.UseUrls(url);
-        builder.AddServices(Substitute.For<Serilog.ILogger>());
+        builder.AddServices();
         foreach (var testService in testServices)
             builder.Services.Replace(testService);
         builder.Services.AddHealthChecks();

--- a/BtmsGateway/Config/ConfigureServices.cs
+++ b/BtmsGateway/Config/ConfigureServices.cs
@@ -7,7 +7,7 @@ using BtmsGateway.Services.Routing;
 using BtmsGateway.Utils.Http;
 using FluentValidation;
 using Microsoft.FeatureManagement;
-using Serilog;
+using ILogger = Serilog.ILogger;
 
 namespace BtmsGateway.Config;
 
@@ -19,12 +19,17 @@ public static class ConfigureServices
     public static IHttpClientBuilder? DecisionComparerHttpClientWithRetryBuilder { get; private set; }
 
     [ExcludeFromCodeCoverage]
-    public static void AddServices(this WebApplicationBuilder builder, bool integrationTest)
+    public static void AddServices(this WebApplicationBuilder builder, ILogger? logger = null)
     {
-        if (integrationTest)
+        if (logger != null)
         {
-            builder.Services.AddSingleton(_ => Log.Logger);
+            // This is added to support end to end tests that boostrap their own configuration
+            // making use of common methods such as this to add the application services. The
+            // end to end tests need to be reworked so they use an actual BTMS gateway host
+            // running in Docker.
+            builder.Services.AddSingleton(_ => logger);
         }
+
         builder.Services.AddHttpLogging(o =>
         {
             o.RequestHeaders.Add("X-cdp-request-id");

--- a/BtmsGateway/Config/ConfigureServices.cs
+++ b/BtmsGateway/Config/ConfigureServices.cs
@@ -7,7 +7,6 @@ using BtmsGateway.Services.Routing;
 using BtmsGateway.Utils.Http;
 using FluentValidation;
 using Microsoft.FeatureManagement;
-using ILogger = Serilog.ILogger;
 
 namespace BtmsGateway.Config;
 
@@ -19,22 +18,19 @@ public static class ConfigureServices
     public static IHttpClientBuilder? DecisionComparerHttpClientWithRetryBuilder { get; private set; }
 
     [ExcludeFromCodeCoverage]
-    public static void AddServices(this WebApplicationBuilder builder, ILogger logger)
+    public static void AddServices(this WebApplicationBuilder builder)
     {
-        builder.Services.AddSingleton(logger);
         builder.Services.AddHttpLogging(o =>
         {
             o.RequestHeaders.Add("X-cdp-request-id");
             o.RequestHeaders.Add("X-Amzn-Trace-Id");
         });
-        HttpRoutedClientWithRetryBuilder = builder.Services.AddHttpProxyRoutedClientWithRetry(logger);
-        HttpForkedClientWithRetryBuilder = builder.Services.AddHttpProxyForkedClientWithRetry(logger);
-        HttpClientWithRetryBuilder = builder.Services.AddHttpProxyClientWithRetry(logger);
-        DecisionComparerHttpClientWithRetryBuilder = builder.Services.AddDecisionComparerHttpProxyClientWithRetry(
-            logger
-        );
+        HttpRoutedClientWithRetryBuilder = builder.Services.AddHttpProxyRoutedClientWithRetry();
+        HttpForkedClientWithRetryBuilder = builder.Services.AddHttpProxyForkedClientWithRetry();
+        HttpClientWithRetryBuilder = builder.Services.AddHttpProxyClientWithRetry();
+        DecisionComparerHttpClientWithRetryBuilder = builder.Services.AddDecisionComparerHttpProxyClientWithRetry();
 
-        builder.Services.AddHttpProxyClientWithoutRetry(logger);
+        builder.Services.AddHttpProxyClientWithoutRetry();
         builder.Services.AddDataApiHttpClient();
 
         builder.Services.AddDefaultAWSOptions(builder.Configuration.GetAWSOptions());

--- a/BtmsGateway/Config/ConfigureServices.cs
+++ b/BtmsGateway/Config/ConfigureServices.cs
@@ -7,6 +7,7 @@ using BtmsGateway.Services.Routing;
 using BtmsGateway.Utils.Http;
 using FluentValidation;
 using Microsoft.FeatureManagement;
+using Serilog;
 
 namespace BtmsGateway.Config;
 
@@ -20,6 +21,7 @@ public static class ConfigureServices
     [ExcludeFromCodeCoverage]
     public static void AddServices(this WebApplicationBuilder builder)
     {
+        builder.Services.AddSingleton(Log.Logger);
         builder.Services.AddHttpLogging(o =>
         {
             o.RequestHeaders.Add("X-cdp-request-id");

--- a/BtmsGateway/Config/ConfigureServices.cs
+++ b/BtmsGateway/Config/ConfigureServices.cs
@@ -19,9 +19,12 @@ public static class ConfigureServices
     public static IHttpClientBuilder? DecisionComparerHttpClientWithRetryBuilder { get; private set; }
 
     [ExcludeFromCodeCoverage]
-    public static void AddServices(this WebApplicationBuilder builder)
+    public static void AddServices(this WebApplicationBuilder builder, bool integrationTest)
     {
-        builder.Services.AddSingleton(Log.Logger);
+        if (integrationTest)
+        {
+            builder.Services.AddSingleton(_ => Log.Logger);
+        }
         builder.Services.AddHttpLogging(o =>
         {
             o.RequestHeaders.Add("X-cdp-request-id");

--- a/BtmsGateway/Extensions/ServiceCollectionExtensions.cs
+++ b/BtmsGateway/Extensions/ServiceCollectionExtensions.cs
@@ -67,11 +67,6 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
-    public static IHttpContextAccessor GetHttpContextAccessor(this IServiceCollection services)
-    {
-        return services.BuildServiceProvider().GetRequiredService<IHttpContextAccessor>();
-    }
-
     public static IServiceCollection AddOperationalMetrics(this IServiceCollection services)
     {
         services.AddSingleton<IRequestMetrics, RequestMetrics>();

--- a/BtmsGateway/Program.cs
+++ b/BtmsGateway/Program.cs
@@ -40,8 +40,8 @@ static void ConfigureWebApplication(WebApplicationBuilder builder)
     builder.Configuration.AddEnvironmentVariables();
     builder.Configuration.AddIniFile("Properties/local.env", true);
     builder.ConfigureLoggingAndTracing();
-    builder.Services.AddCustomTrustStore(Log.Logger);
-    builder.AddServices(Log.Logger);
+    builder.Services.AddCustomTrustStore();
+    builder.AddServices();
 
     var routingConfig = builder.ConfigureToType<RoutingConfig>();
     var healthCheckConfig = builder.ConfigureToType<HealthCheckConfig>();

--- a/BtmsGateway/Program.cs
+++ b/BtmsGateway/Program.cs
@@ -41,7 +41,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder)
     builder.Configuration.AddIniFile("Properties/local.env", true);
     builder.ConfigureLoggingAndTracing();
     builder.Services.AddCustomTrustStore();
-    builder.AddServices();
+    builder.AddServices(integrationTest: false);
 
     var routingConfig = builder.ConfigureToType<RoutingConfig>();
     var healthCheckConfig = builder.ConfigureToType<HealthCheckConfig>();

--- a/BtmsGateway/Program.cs
+++ b/BtmsGateway/Program.cs
@@ -42,7 +42,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder)
     builder.Configuration.AddIniFile("Properties/local.env", true);
     builder.ConfigureLoggingAndTracing();
     builder.Services.AddCustomTrustStore();
-    builder.AddServices(integrationTest: false);
+    builder.AddServices();
 
     var routingConfig = builder.ConfigureToType<RoutingConfig>();
     var healthCheckConfig = builder.ConfigureToType<HealthCheckConfig>();

--- a/BtmsGateway/Program.cs
+++ b/BtmsGateway/Program.cs
@@ -6,9 +6,10 @@ using BtmsGateway.Services.Metrics;
 using BtmsGateway.Services.Routing;
 using BtmsGateway.Utils;
 using BtmsGateway.Utils.Logging;
+using Elastic.CommonSchema.Serilog;
 using Serilog;
 
-Log.Logger = new LoggerConfiguration().WriteTo.Console().CreateBootstrapLogger();
+Log.Logger = new LoggerConfiguration().WriteTo.Console(new EcsTextFormatter()).CreateBootstrapLogger();
 
 try
 {

--- a/BtmsGateway/Utils/TrustStore.cs
+++ b/BtmsGateway/Utils/TrustStore.cs
@@ -8,14 +8,13 @@ namespace BtmsGateway.Utils;
 [ExcludeFromCodeCoverage]
 public static class TrustStore
 {
-    public static void AddCustomTrustStore(this IServiceCollection _, Serilog.ILogger logger)
+    public static void AddCustomTrustStore(this IServiceCollection _)
     {
-        logger.Information("Loading Certificates into Trust store");
-        var certificates = GetCertificates(logger);
+        var certificates = GetCertificates();
         AddCertificates(certificates);
     }
 
-    private static List<string> GetCertificates(Serilog.ILogger logger)
+    private static List<string> GetCertificates()
     {
         return Environment
             .GetEnvironmentVariables()
@@ -26,7 +25,6 @@ public static class TrustStore
             .Select(entry =>
             {
                 var data = Convert.FromBase64String(entry.Value!.ToString() ?? "");
-                logger.Information("{EntryKey} certificate decoded", entry.Key);
                 return Encoding.UTF8.GetString(data);
             })
             .ToList();


### PR DESCRIPTION
As per PR title.

We have observed that logs made during startup do not report correctly within CDP. As these logs provide minimal to no value anyway, we are getting rid of them.

Any Fatal failure to startup will be caught and logged by the try/catch around the startup process.

We now include the `EcsTextFormatter` in the reloadable bootstrap logger that is created during startup to try and avoid logs reaching CDP that are in the incorrect format.

As the end to end tests do not startup an actual gateway host using `Program.cs`, only some of the configuration is triggered, which means the logging setup does not get exercised in full.

The end to end tests are due to be refactored so they are not in memory and are running within a contained Docker environment as our other services are. But until then, we inject a substitute `ILogger`, which is configured as a singleton in DI. For normal system operation where the gateway host is being driven through `Program.cs`, the natural logging DI setup will be triggered and the `ILogger` will be set via the `UseSerilog` call.