### PR TITLE
Add ResourceId into the logging, which will be included if present

### DIFF
--- a/BtmsGateway/Extensions/ConsumerContextExtensions.cs
+++ b/BtmsGateway/Extensions/ConsumerContextExtensions.cs
@@ -9,6 +9,7 @@ public static class MessageBusHeaders
     public const string ResourceType = nameof(ResourceType);
     public const string SubResourceType = nameof(SubResourceType);
     public const string SqsBusMessage = "Sqs_Message";
+    public const string ResourceId = nameof(ResourceId);
 }
 
 [ExcludeFromCodeCoverage]
@@ -39,6 +40,16 @@ public static class ConsumerContextExtensions
         if (consumerContext.Properties.TryGetValue(MessageBusHeaders.SqsBusMessage, out var sqsMessage))
         {
             return ((Message)sqsMessage).MessageId;
+        }
+
+        return string.Empty;
+    }
+
+    public static string GetResourceId(this IConsumerContext consumerContext)
+    {
+        if (consumerContext.Headers.TryGetValue(MessageBusHeaders.ResourceId, out var value))
+        {
+            return value.ToString()!;
         }
 
         return string.Empty;

--- a/BtmsGateway/Extensions/ConsumerContextExtensions.cs
+++ b/BtmsGateway/Extensions/ConsumerContextExtensions.cs
@@ -4,6 +4,7 @@ using SlimMessageBus;
 
 namespace BtmsGateway.Extensions;
 
+[ExcludeFromCodeCoverage]
 public static class MessageBusHeaders
 {
     public const string ResourceType = nameof(ResourceType);

--- a/BtmsGateway/Utils/Logging/LoggingInterceptor.cs
+++ b/BtmsGateway/Utils/Logging/LoggingInterceptor.cs
@@ -13,7 +13,8 @@ public class LoggingInterceptor<TMessage>(ILogger<LoggingInterceptor<TMessage>> 
     public async Task<object> OnHandle(TMessage message, Func<Task<object>> next, IConsumerContext context)
     {
         var messageId = context.GetMessageId();
-        logger.LogInformation("Processing MessageId {MessageId}", messageId);
+        var resourceId = context.GetResourceId();
+        logger.LogInformation("Processing message {MessageId} for resource {ResourceId}", messageId, resourceId);
 
         try
         {
@@ -22,12 +23,22 @@ public class LoggingInterceptor<TMessage>(ILogger<LoggingInterceptor<TMessage>> 
         catch (HttpRequestException httpRequestException)
             when (httpRequestException.StatusCode == HttpStatusCode.Conflict)
         {
-            logger.LogWarning(httpRequestException, "409 Conflict Processing MessageId {MessageId}", messageId);
+            logger.LogWarning(
+                httpRequestException,
+                "409 Conflict processing message {MessageId} for resource {ResourceId}",
+                messageId,
+                resourceId
+            );
             throw;
         }
         catch (Exception exception)
         {
-            logger.LogError(exception, "Error Processing MessageId {MessageId}", messageId);
+            logger.LogError(
+                exception,
+                "Error processing message {MessageId} for resource {ResourceId}",
+                messageId,
+                resourceId
+            );
             throw;
         }
     }

--- a/BtmsGateway/Utils/Logging/WebApplicationBuilderExtensions.cs
+++ b/BtmsGateway/Utils/Logging/WebApplicationBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace BtmsGateway.Utils.Logging;
 [ExcludeFromCodeCoverage]
 public static class WebApplicationBuilderExtensions
 {
-    public static void ConfigureLoggingAndTracing(this WebApplicationBuilder builder, bool integrationTest = false)
+    public static void ConfigureLoggingAndTracing(this WebApplicationBuilder builder)
     {
         builder.Services.AddHttpContextAccessor();
         builder.Services.TryAddSingleton<ITraceContextAccessor, TraceContextAccessor>();
@@ -42,13 +42,7 @@ public static class WebApplicationBuilderExtensions
         });
         builder.Services.TryAddSingleton<HeaderPropagationValues>();
 
-        if (!integrationTest)
-        {
-            // Configuring Serilog below wipes out the framework logging
-            // so we don't execute the following when the host is running
-            // within an integration test
-            builder.Host.UseSerilog(ConfigureLogging);
-        }
+        builder.Host.UseSerilog(ConfigureLogging);
     }
 
     private static void ConfigureLogging(


### PR DESCRIPTION
As per PR title.

Also included an amend to the configure logging method to remove the `integrationTest` param as it's not used and gives the impression it's consumed in tests, which is not the case.