### PR TITLE
CDMS-801: remove call to Data API in Clearance Decision Consumer

### DIFF
--- a/BtmsGateway.Test/Consumers/ConsumerMediatorTests.cs
+++ b/BtmsGateway.Test/Consumers/ConsumerMediatorTests.cs
@@ -4,7 +4,6 @@ using BtmsGateway.Domain;
 using BtmsGateway.Exceptions;
 using BtmsGateway.Extensions;
 using BtmsGateway.Services.Routing;
-using Defra.TradeImportsDataApi.Api.Client;
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 using Defra.TradeImportsDataApi.Domain.Errors;
 using Defra.TradeImportsDataApi.Domain.Events;
@@ -28,7 +27,6 @@ public class ConsumerMediatorTests
             }
         );
         var subject = new ConsumerMediator(
-            Substitute.For<ITradeImportsDataApiClient>(),
             Substitute.For<IDecisionSender>(),
             Substitute.For<IErrorNotificationSender>(),
             Substitute.For<ILoggerFactory>()
@@ -65,7 +63,6 @@ public class ConsumerMediatorTests
             }
         );
         var subject = new ConsumerMediator(
-            Substitute.For<ITradeImportsDataApiClient>(),
             Substitute.For<IDecisionSender>(),
             Substitute.For<IErrorNotificationSender>(),
             Substitute.For<ILoggerFactory>()
@@ -102,7 +99,6 @@ public class ConsumerMediatorTests
             }
         );
         var subject = new ConsumerMediator(
-            Substitute.For<ITradeImportsDataApiClient>(),
             Substitute.For<IDecisionSender>(),
             Substitute.For<IErrorNotificationSender>(),
             Substitute.For<ILoggerFactory>()

--- a/BtmsGateway/Consumers/ClearanceDecisionConsumer.cs
+++ b/BtmsGateway/Consumers/ClearanceDecisionConsumer.cs
@@ -3,18 +3,14 @@ using BtmsGateway.Exceptions;
 using BtmsGateway.Services.Converter;
 using BtmsGateway.Services.Routing;
 using BtmsGateway.Utils;
-using Defra.TradeImportsDataApi.Api.Client;
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 using Defra.TradeImportsDataApi.Domain.Events;
 using SlimMessageBus;
 
 namespace BtmsGateway.Consumers;
 
-public class ClearanceDecisionConsumer(
-    ITradeImportsDataApiClient api,
-    IDecisionSender decisionSender,
-    ILogger<ClearanceDecisionConsumer> logger
-) : IConsumer<ResourceEvent<CustomsDeclaration>>
+public class ClearanceDecisionConsumer(IDecisionSender decisionSender, ILogger<ClearanceDecisionConsumer> logger)
+    : IConsumer<ResourceEvent<CustomsDeclaration>>
 {
     public async Task OnHandle(ResourceEvent<CustomsDeclaration> message, CancellationToken cancellationToken)
     {
@@ -33,15 +29,15 @@ public class ClearanceDecisionConsumer(
 
         try
         {
-            var customsDeclaration = await api.GetCustomsDeclaration(mrn, cancellationToken);
-
-            if (customsDeclaration is null)
+            if (message.Resource is null)
             {
-                logger.LogError("{MRN} Customs Declaration not found from Data API.", mrn);
-                throw new InvalidOperationException($"{mrn} Customs Declaration not found from Data API.");
+                logger.LogError("{MRN} Customs Declaration Resource Event contained a null resource.", mrn);
+                throw new InvalidOperationException(
+                    $"{mrn} Customs Declaration Resource Event contained a null resource."
+                );
             }
 
-            if (customsDeclaration.ClearanceDecision is null)
+            if (message.Resource.ClearanceDecision is null)
             {
                 logger.LogError("{MRN} Customs Declaration does not contain a Clearance Decision.", mrn);
                 throw new InvalidOperationException(
@@ -49,14 +45,14 @@ public class ClearanceDecisionConsumer(
                 );
             }
 
-            var soapMessage = ClearanceDecisionToSoapConverter.Convert(customsDeclaration.ClearanceDecision, mrn);
+            var soapMessage = ClearanceDecisionToSoapConverter.Convert(message.Resource.ClearanceDecision, mrn);
 
             var result = await decisionSender.SendDecisionAsync(
                 mrn,
                 soapMessage,
                 MessagingConstants.MessageSource.Btms,
                 new RoutingResult(),
-                correlationId: customsDeclaration.ClearanceDecision.CorrelationId,
+                correlationId: message.Resource.ClearanceDecision.CorrelationId,
                 cancellationToken: cancellationToken
             );
 

--- a/BtmsGateway/Consumers/ConsumerMediator.cs
+++ b/BtmsGateway/Consumers/ConsumerMediator.cs
@@ -2,16 +2,13 @@ using System.Text.Json;
 using BtmsGateway.Domain;
 using BtmsGateway.Extensions;
 using BtmsGateway.Services.Routing;
-using Defra.TradeImportsDataApi.Api.Client;
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
-using Defra.TradeImportsDataApi.Domain.Errors;
 using Defra.TradeImportsDataApi.Domain.Events;
 using SlimMessageBus;
 
 namespace BtmsGateway.Consumers;
 
 public class ConsumerMediator(
-    ITradeImportsDataApiClient api,
     IDecisionSender decisionSender,
     IErrorNotificationSender errorNotificationSender,
     ILoggerFactory loggerFactory
@@ -36,7 +33,6 @@ public class ConsumerMediator(
     private Task HandleCustomsDeclaration(JsonElement message, CancellationToken cancellationToken)
     {
         var consumer = new ClearanceDecisionConsumer(
-            api,
             decisionSender,
             loggerFactory.CreateLogger<ClearanceDecisionConsumer>()
         );


### PR DESCRIPTION
- Removed unnecessary call to Data API to retrieve the Customs Declaration as its already present in the Resource Event message