### PR TITLE
CDMS-520: removes default host header values that were being applied in Dev environment

### DIFF
--- a/BtmsGateway/appsettings.json
+++ b/BtmsGateway/appsettings.json
@@ -141,13 +141,11 @@
       },
       "CdsAlvs": {
         "LinkType": "Url",
-        "Link": "https://10.62.146.246/",
-        "HostHeader": "t2.secure.services.defra.gsi.gov.uk"
+        "Link": "https://10.62.146.246/"
       },
       "AlvsCds": {
         "LinkType": "Url",
-        "Link": "https://10.102.9.31/",
-        "HostHeader": "syst32.hmrc.gov.uk"
+        "Link": "https://10.102.9.31/"
       },
       "AlvsIpaffs": {
         "LinkType": "Url",
@@ -172,7 +170,6 @@
         "Link": "http://btms-gateway-stub.localtest.me:3092",
         "RoutePath": "/ws/CDS/defra/alvsclearanceinbound/v1",
         "ContentType": "application/soap+xml",
-        "HostHeader": "syst32.hmrc.gov.uk",
         "Method": "POST"
       },
       "BtmsDecisionComparer": {


### PR DESCRIPTION
- Dev config settings in cdp-app-config were not overriding the appsettings and it was defaulting to these values. Removed the defaults as they're not needed