### PR TITLE
CDMS-418: returning successful responses for HRMC requests when primary routing is going to BTMS backend topic

### DIFF
--- a/BtmsGateway.Test/Services/Routing/QueueSenderTests.cs
+++ b/BtmsGateway.Test/Services/Routing/QueueSenderTests.cs
@@ -12,7 +12,7 @@ namespace BtmsGateway.Test.Services.Routing;
 public class QueueSenderTests
 {
     IConfiguration config = new ConfigurationBuilder()
-        .AddInMemoryCollection(new List<KeyValuePair<string, string>>() { new("traceHeader", "trace-header") })
+        .AddInMemoryCollection(new List<KeyValuePair<string, string>> { new("traceHeader", "trace-header") })
         .Build();
 
     [Fact]
@@ -21,7 +21,7 @@ public class QueueSenderTests
         // Arrange
         var mocks = CreateMocks(HttpStatusCode.BadRequest);
         var msgData = await TestHelpers.CreateMessageData(mocks.Logger);
-        var sut = new QueueSender(mocks.SnsService, config);
+        var sut = new QueueSender(mocks.SnsService, config, mocks.Logger);
 
         // Act
         var response = await sut.Send(msgData.Routing, msgData.MessageData, "");
@@ -29,6 +29,7 @@ public class QueueSenderTests
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         response.RoutingSuccessful.Should().BeFalse();
+        response.ResponseContent.Should().Contain("Failed to publish message to inbound topic");
     }
 
     [Fact]
@@ -37,7 +38,7 @@ public class QueueSenderTests
         // Arrange
         var mocks = CreateMocks();
         var msgData = await TestHelpers.CreateMessageData(mocks.Logger);
-        var sut = new QueueSender(mocks.SnsService, config);
+        var sut = new QueueSender(mocks.SnsService, config, mocks.Logger);
 
         // Act
         var response = await sut.Send(msgData.Routing, msgData.MessageData, "");
@@ -45,6 +46,7 @@ public class QueueSenderTests
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.RoutingSuccessful.Should().BeTrue();
+        response.ResponseContent.Should().Contain("<StatusCode>000</StatusCode>");
     }
 
     [Fact]
@@ -53,7 +55,7 @@ public class QueueSenderTests
         // Arrange
         var mocks = CreateMocks(HttpStatusCode.BadRequest);
         var msgData = await TestHelpers.CreateMessageData(mocks.Logger);
-        var sut = new QueueSender(mocks.SnsService, config);
+        var sut = new QueueSender(mocks.SnsService, config, mocks.Logger);
 
         // Act
         var response = await sut.Send(msgData.Routing, msgData.MessageData, "");
@@ -61,6 +63,7 @@ public class QueueSenderTests
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         response.RoutingSuccessful.Should().BeFalse();
+        response.ResponseContent.Should().Contain("Failed to publish message to inbound topic");
     }
 
     [Fact]
@@ -69,7 +72,7 @@ public class QueueSenderTests
         // Arrange
         var mocks = CreateMocks();
         var msgData = await TestHelpers.CreateMessageData(mocks.Logger);
-        var sut = new QueueSender(mocks.SnsService, config);
+        var sut = new QueueSender(mocks.SnsService, config, mocks.Logger);
 
         // Act
         var response = await sut.Send(msgData.Routing, msgData.MessageData, "");
@@ -77,6 +80,7 @@ public class QueueSenderTests
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.RoutingSuccessful.Should().BeTrue();
+        response.ResponseContent.Should().Contain("<StatusCode>000</StatusCode>");
     }
 
     [Fact]
@@ -85,7 +89,7 @@ public class QueueSenderTests
         // Arrange
         var mocks = CreateMocks();
         var msgData = await TestHelpers.CreateMessageData(mocks.Logger);
-        var sut = new QueueSender(mocks.SnsService, config);
+        var sut = new QueueSender(mocks.SnsService, config, mocks.Logger);
 
         // Act
         var response = await sut.Send(msgData.Routing, msgData.MessageData, "");
@@ -93,6 +97,7 @@ public class QueueSenderTests
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.RoutingSuccessful.Should().BeTrue();
+        response.ResponseContent.Should().Contain("<StatusCode>000</StatusCode>");
     }
 
     private static (IAmazonSimpleNotificationService SnsService, ILogger Logger) CreateMocks(

--- a/BtmsGateway/Services/Converter/SoapUtils.cs
+++ b/BtmsGateway/Services/Converter/SoapUtils.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Xml.Linq;
+using BtmsGateway.Domain;
 
 namespace BtmsGateway.Services.Converter;
 
@@ -24,6 +25,14 @@ public static class SoapUtils
     private static readonly XAttribute AlvsSecurityNsAttribute = new(XNamespace.Xmlns + "NS2", OasNs);
     private static readonly XAttribute AlvsCommonRootNsAttribute = new(XNamespace.Xmlns + "NS3", AlvsCommonRootNs);
 
+    //HMRC requests success responses
+    private static string SuccessfulAlvsClearanceResponseBody =>
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n\t<soapenv:Body>\n\t\t<ALVSClearanceResponse xmlns=\"http://submitimportdocumenthmrcfacade.types.esb.ws.cara.defra.com\" xmlns:ns2=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" xmlns:ns3=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\">\n\t\t\t<StatusCode>000</StatusCode>\n\t\t</ALVSClearanceResponse>\n\t</soapenv:Body>\n</soapenv:Envelope>";
+    private static string SuccessfulFinalisationNotificationResponseBody =>
+        "<?xml version=\\\"1.0\\\" encoding=\\\"utf-8\\\"?>\n<soapenv:Envelope xmlns:soapenv=\\\"http://www.w3.org/2003/05/soap-envelope\\\">\n\t<soapenv:Body>\n\t\t<FinalisationNotificationResponse xmlns=\\\"http://notifyfinalisedstatehmrcfacade.types.esb.ws.cara.defra.com\\\" xmlns:ns2=\\\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\\\" xmlns:ns3=\\\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\\\">\n\t\t\t<StatusCode>000</StatusCode>\n\t\t</FinalisationNotificationResponse>\n\t</soapenv:Body>\n</soapenv:Envelope>";
+    private static string SuccessfulAlvsErrorNotificationResponseBody =>
+        "<?xml version=\\\"1.0\\\" encoding=\\\"utf-8\\\"?>\n<soapenv:Envelope xmlns:soapenv=\\\"http://www.w3.org/2003/05/soap-envelope\\\">\n\t<soapenv:Body>\n\t\t<ALVSErrorNotificationResponse xmlns=\\\"http://alvserrornotification.types.esb.ws.cara.defra.com\\\" xmlns:ns2=\\\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\\\" xmlns:ns3=\\\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\\\">\n\t\t\t<StatusCode>000</StatusCode>\n\t\t</ALVSErrorNotificationResponse>\n\t</soapenv:Body>\n</soapenv:Envelope>";
+
     public static XElement AddSoapEnvelope(XElement rootElement, SoapType soapType)
     {
         return soapType switch
@@ -32,6 +41,19 @@ public static class SoapUtils
             SoapType.AlvsToCds => GetAlvsToCdsSoapEnvelope(rootElement),
             SoapType.AlvsToIpaffs => GetAlvsToIpaffsSoapEnvelope(rootElement),
             _ => throw new ArgumentOutOfRangeException(nameof(soapType), soapType, "Unknown message soap type"),
+        };
+    }
+
+    public static string? GetMessageTypeSuccessResponse(string? messageSubXPath)
+    {
+        return messageSubXPath switch
+        {
+            MessagingConstants.SoapMessageTypes.ALVSClearanceRequest => SuccessfulAlvsClearanceResponseBody,
+            MessagingConstants.SoapMessageTypes.FinalisationNotificationRequest =>
+                SuccessfulFinalisationNotificationResponseBody,
+            MessagingConstants.SoapMessageTypes.ALVSErrorNotificationRequest =>
+                SuccessfulAlvsErrorNotificationResponseBody,
+            _ => null,
         };
     }
 


### PR DESCRIPTION
- When BTMS becomes the primary route for HMRC CDS requests going to ALVS, then Gateway needs to respond with a successful SOAP response if the request is successfully received and published to our Inbound Topic