### PR TITLE
Cdms 851 log 409 as warnings

### DIFF
--- a/BtmsGateway.Test/Consumers/ClearanceDecisionConsumerTests.cs
+++ b/BtmsGateway.Test/Consumers/ClearanceDecisionConsumerTests.cs
@@ -211,4 +211,27 @@ public class ClearanceDecisionConsumerTests
                 Arg.Any<CancellationToken>()
             );
     }
+
+    [Fact]
+    public async Task When_sending_to_comparer_returns_conflict_exception_Then_conflict_exception_is_thrown()
+    {
+        _decisionSender
+            .SendDecisionAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<MessagingConstants.MessageSource>(),
+                Arg.Any<RoutingResult>(),
+                Arg.Any<IHeaderDictionary>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(new ConflictException("Something went wrong"));
+
+        var thrownException = await Assert.ThrowsAsync<ConflictException>(() =>
+            _consumer.OnHandle(_message, CancellationToken.None)
+        );
+        thrownException.Message.Should().Be("24GB123456789AB012 Failed to process clearance decision resource event.");
+        thrownException.InnerException.Should().BeAssignableTo<Exception>();
+        thrownException.InnerException?.Message.Should().Be("Something went wrong");
+    }
 }

--- a/BtmsGateway.Test/Services/Routing/DecisionSenderTests.cs
+++ b/BtmsGateway.Test/Services/Routing/DecisionSenderTests.cs
@@ -354,7 +354,7 @@ public class DecisionSenderTests
                 Arg.Any<string>()
             );
     }
-    
+
     [Fact]
     public async Task When_sending_decision_and_comparer_returns_conflict_status_response_Then_exception_is_thrown()
     {

--- a/BtmsGateway.Test/Services/Routing/DecisionSenderTests.cs
+++ b/BtmsGateway.Test/Services/Routing/DecisionSenderTests.cs
@@ -370,7 +370,7 @@ public class DecisionSenderTests
             )
             .Returns(comparerResponse);
 
-        var thrownException = await Assert.ThrowsAsync<DecisionComparisonException>(() =>
+        var thrownException = await Assert.ThrowsAsync<ConflictException>(() =>
             _decisionSender.SendDecisionAsync(
                 "mrn-123",
                 "<AlvsDecisionNotification />",

--- a/BtmsGateway.Test/Services/Routing/DecisionSenderTests.cs
+++ b/BtmsGateway.Test/Services/Routing/DecisionSenderTests.cs
@@ -335,8 +335,26 @@ public class DecisionSenderTests
         );
         thrownException.Message.Should().Be("mrn-123 Failed to send Decision to Decision Comparer.");
 
-        _logger.Received(1).Error(Arg.Any<string>());
-        _logger.DidNotReceiveWithAnyArgs().Warning(Arg.Any<string>());
+        _logger
+            .Received(1)
+            .Error(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<HttpStatusCode>(),
+                Arg.Any<string>()
+            );
+        _logger
+            .DidNotReceiveWithAnyArgs()
+            .Warning(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<HttpStatusCode>(),
+                Arg.Any<string>()
+            );
     }
 
     [Fact]
@@ -367,8 +385,26 @@ public class DecisionSenderTests
         );
         thrownException.Message.Should().Be("mrn-123 Failed to send Decision to Decision Comparer.");
 
-        _logger.Received(1).Warning(Arg.Any<string>());
-        _logger.DidNotReceiveWithAnyArgs().Error(Arg.Any<string>());
+        _logger
+            .Received(1)
+            .Warning(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<HttpStatusCode>(),
+                Arg.Any<string>()
+            );
+        _logger
+            .DidNotReceiveWithAnyArgs()
+            .Error(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<HttpStatusCode>(),
+                Arg.Any<string>()
+            );
     }
 
     [Fact]

--- a/BtmsGateway.Test/Services/Routing/DecisionSenderTests.cs
+++ b/BtmsGateway.Test/Services/Routing/DecisionSenderTests.cs
@@ -334,6 +334,73 @@ public class DecisionSenderTests
             )
         );
         thrownException.Message.Should().Be("mrn-123 Failed to send Decision to Decision Comparer.");
+
+        _logger
+            .Received(1)
+            .Error(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<HttpStatusCode>(),
+                Arg.Any<string>()
+            );
+        _logger
+            .DidNotReceiveWithAnyArgs()
+            .Warning(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<HttpStatusCode>(),
+                Arg.Any<string>()
+            );
+    }
+    
+    [Fact]
+    public async Task When_sending_decision_and_comparer_returns_conflict_status_response_Then_exception_is_thrown()
+    {
+        var comparerResponse = new HttpResponseMessage(HttpStatusCode.Conflict);
+
+        _apiSender
+            .SendToDecisionComparerAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<IHeaderDictionary>()
+            )
+            .Returns(comparerResponse);
+
+        var thrownException = await Assert.ThrowsAsync<DecisionComparisonException>(() =>
+            _decisionSender.SendDecisionAsync(
+                "mrn-123",
+                "<AlvsDecisionNotification />",
+                MessagingConstants.MessageSource.Alvs,
+                new RoutingResult(),
+                new HeaderDictionary(),
+                "external-correlation-id",
+                CancellationToken.None
+            )
+        );
+        thrownException.Message.Should().Be("mrn-123 Failed to send Decision to Decision Comparer.");
+
+        _logger
+            .Received(1)
+            .Warning(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<HttpStatusCode>(),
+                Arg.Any<string>()
+            );
+        _logger
+            .DidNotReceiveWithAnyArgs()
+            .Error(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<HttpStatusCode>(),
+                Arg.Any<string>()
+            );
     }
 
     [Fact]

--- a/BtmsGateway.Test/Services/Routing/DecisionSenderTests.cs
+++ b/BtmsGateway.Test/Services/Routing/DecisionSenderTests.cs
@@ -335,24 +335,8 @@ public class DecisionSenderTests
         );
         thrownException.Message.Should().Be("mrn-123 Failed to send Decision to Decision Comparer.");
 
-        _logger
-            .Received(1)
-            .Error(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<HttpStatusCode>(),
-                Arg.Any<string>()
-            );
-        _logger
-            .DidNotReceiveWithAnyArgs()
-            .Warning(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<HttpStatusCode>(),
-                Arg.Any<string>()
-            );
+        _logger.Received(1).Error(Arg.Any<string>());
+        _logger.DidNotReceiveWithAnyArgs().Warning(Arg.Any<string>());
     }
 
     [Fact]
@@ -383,24 +367,8 @@ public class DecisionSenderTests
         );
         thrownException.Message.Should().Be("mrn-123 Failed to send Decision to Decision Comparer.");
 
-        _logger
-            .Received(1)
-            .Warning(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<HttpStatusCode>(),
-                Arg.Any<string>()
-            );
-        _logger
-            .DidNotReceiveWithAnyArgs()
-            .Error(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<HttpStatusCode>(),
-                Arg.Any<string>()
-            );
+        _logger.Received(1).Warning(Arg.Any<string>());
+        _logger.DidNotReceiveWithAnyArgs().Error(Arg.Any<string>());
     }
 
     [Fact]

--- a/BtmsGateway.Test/Services/Routing/ErrorNotificationSenderTests.cs
+++ b/BtmsGateway.Test/Services/Routing/ErrorNotificationSenderTests.cs
@@ -447,24 +447,8 @@ public class ErrorNotificationSenderTests
         );
         thrownException.Message.Should().Be("mrn-123 Failed to send Error Notification to Decision Comparer.");
 
-        _logger
-            .Received(1)
-            .Error(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<HttpStatusCode>(),
-                Arg.Any<string>()
-            );
-        _logger
-            .DidNotReceiveWithAnyArgs()
-            .Warning(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<HttpStatusCode>(),
-                Arg.Any<string>()
-            );
+        _logger.Received(1).Error(Arg.Any<string>());
+        _logger.DidNotReceiveWithAnyArgs().Warning(Arg.Any<string>());
     }
 
     [Fact]
@@ -493,24 +477,8 @@ public class ErrorNotificationSenderTests
         );
         thrownException.Message.Should().Be("mrn-123 Failed to send Error Notification to Decision Comparer.");
 
-        _logger
-            .Received(1)
-            .Warning(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<HttpStatusCode>(),
-                Arg.Any<string>()
-            );
-        _logger
-            .DidNotReceiveWithAnyArgs()
-            .Error(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<string>(),
-                Arg.Any<HttpStatusCode>(),
-                Arg.Any<string>()
-            );
+        _logger.Received(1).Warning(Arg.Any<string>());
+        _logger.DidNotReceiveWithAnyArgs().Error(Arg.Any<string>());
     }
 
     // [Fact]

--- a/BtmsGateway.Test/Services/Routing/ErrorNotificationSenderTests.cs
+++ b/BtmsGateway.Test/Services/Routing/ErrorNotificationSenderTests.cs
@@ -447,8 +447,26 @@ public class ErrorNotificationSenderTests
         );
         thrownException.Message.Should().Be("mrn-123 Failed to send Error Notification to Decision Comparer.");
 
-        _logger.Received(1).Error(Arg.Any<string>());
-        _logger.DidNotReceiveWithAnyArgs().Warning(Arg.Any<string>());
+        _logger
+            .Received(1)
+            .Error(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<HttpStatusCode>(),
+                Arg.Any<string>()
+            );
+        _logger
+            .DidNotReceiveWithAnyArgs()
+            .Warning(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<HttpStatusCode>(),
+                Arg.Any<string>()
+            );
     }
 
     [Fact]
@@ -477,8 +495,26 @@ public class ErrorNotificationSenderTests
         );
         thrownException.Message.Should().Be("mrn-123 Failed to send Error Notification to Decision Comparer.");
 
-        _logger.Received(1).Warning(Arg.Any<string>());
-        _logger.DidNotReceiveWithAnyArgs().Error(Arg.Any<string>());
+        _logger
+            .Received(1)
+            .Warning(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<HttpStatusCode>(),
+                Arg.Any<string>()
+            );
+        _logger
+            .DidNotReceiveWithAnyArgs()
+            .Error(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<HttpStatusCode>(),
+                Arg.Any<string>()
+            );
     }
 
     // [Fact]

--- a/BtmsGateway.Test/Services/Routing/ErrorNotificationSenderTests.cs
+++ b/BtmsGateway.Test/Services/Routing/ErrorNotificationSenderTests.cs
@@ -482,7 +482,7 @@ public class ErrorNotificationSenderTests
             )
             .Returns(comparerResponse);
 
-        var thrownException = await Assert.ThrowsAsync<DecisionComparisonException>(() =>
+        var thrownException = await Assert.ThrowsAsync<ConflictException>(() =>
             _errorNotificationSender.SendErrorNotificationAsync(
                 "mrn-123",
                 "<HMRCErrorNotification />",

--- a/BtmsGateway.Test/Services/Routing/ErrorNotificationSenderTests.cs
+++ b/BtmsGateway.Test/Services/Routing/ErrorNotificationSenderTests.cs
@@ -446,7 +446,7 @@ public class ErrorNotificationSenderTests
             )
         );
         thrownException.Message.Should().Be("mrn-123 Failed to send Error Notification to Decision Comparer.");
-        
+
         _logger
             .Received(1)
             .Error(
@@ -466,7 +466,7 @@ public class ErrorNotificationSenderTests
                 Arg.Any<string>()
             );
     }
-    
+
     [Fact]
     public async Task When_sending_error_notification_and_comparer_returns_conflict_status_response_Then_exception_is_thrown()
     {
@@ -492,7 +492,7 @@ public class ErrorNotificationSenderTests
             )
         );
         thrownException.Message.Should().Be("mrn-123 Failed to send Error Notification to Decision Comparer.");
-        
+
         _logger
             .Received(1)
             .Warning(

--- a/BtmsGateway.Test/Services/Routing/ErrorNotificationSenderTests.cs
+++ b/BtmsGateway.Test/Services/Routing/ErrorNotificationSenderTests.cs
@@ -446,6 +446,71 @@ public class ErrorNotificationSenderTests
             )
         );
         thrownException.Message.Should().Be("mrn-123 Failed to send Error Notification to Decision Comparer.");
+        
+        _logger
+            .Received(1)
+            .Error(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<HttpStatusCode>(),
+                Arg.Any<string>()
+            );
+        _logger
+            .DidNotReceiveWithAnyArgs()
+            .Warning(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<HttpStatusCode>(),
+                Arg.Any<string>()
+            );
+    }
+    
+    [Fact]
+    public async Task When_sending_error_notification_and_comparer_returns_conflict_status_response_Then_exception_is_thrown()
+    {
+        var comparerResponse = new HttpResponseMessage(HttpStatusCode.Conflict);
+
+        _apiSender
+            .SendToDecisionComparerAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<IHeaderDictionary>()
+            )
+            .Returns(comparerResponse);
+
+        var thrownException = await Assert.ThrowsAsync<DecisionComparisonException>(() =>
+            _errorNotificationSender.SendErrorNotificationAsync(
+                "mrn-123",
+                "<HMRCErrorNotification />",
+                MessagingConstants.MessageSource.Btms,
+                new RoutingResult(),
+                cancellationToken: CancellationToken.None
+            )
+        );
+        thrownException.Message.Should().Be("mrn-123 Failed to send Error Notification to Decision Comparer.");
+        
+        _logger
+            .Received(1)
+            .Warning(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<HttpStatusCode>(),
+                Arg.Any<string>()
+            );
+        _logger
+            .DidNotReceiveWithAnyArgs()
+            .Error(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<HttpStatusCode>(),
+                Arg.Any<string>()
+            );
     }
 
     // [Fact]

--- a/BtmsGateway/Consumers/ClearanceDecisionConsumer.cs
+++ b/BtmsGateway/Consumers/ClearanceDecisionConsumer.cs
@@ -75,6 +75,11 @@ public class ClearanceDecisionConsumer(IDecisionSender decisionSender, ILogger<C
                 mrn
             );
         }
+        catch (ConflictException ex)
+        {
+            logger.LogWarning(ex, "{MRN} Failed to process clearance decision resource event.", mrn);
+            throw new ConflictException($"{mrn} Failed to process clearance decision resource event.", ex);
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "{MRN} Failed to process clearance decision resource event.", mrn);

--- a/BtmsGateway/Consumers/ProcessingErrorConsumer.cs
+++ b/BtmsGateway/Consumers/ProcessingErrorConsumer.cs
@@ -69,6 +69,11 @@ public class ProcessingErrorConsumer(
                 mrn
             );
         }
+        catch (ConflictException ex)
+        {
+            logger.LogWarning(ex, "{MRN} Failed to process processing error resource event.", mrn);
+            throw new ConflictException($"{mrn} Failed to process processing error resource event.", ex);
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "{MRN} Failed to process processing error resource event.", mrn);

--- a/BtmsGateway/Exceptions/ConflictException.cs
+++ b/BtmsGateway/Exceptions/ConflictException.cs
@@ -1,0 +1,10 @@
+namespace BtmsGateway.Exceptions;
+
+public class ConflictException : Exception
+{
+    public ConflictException(string message)
+        : base(message) { }
+
+    public ConflictException(string message, Exception inner)
+        : base(message, inner) { }
+}

--- a/BtmsGateway/Services/Routing/DecisionSender.cs
+++ b/BtmsGateway/Services/Routing/DecisionSender.cs
@@ -84,29 +84,11 @@ public class DecisionSender : SoapMessageSenderBase, IDecisionSender
             headers
         );
 
-        if (comparerResponse.StatusCode == HttpStatusCode.Conflict)
-        {
-            _logger.Warning(
-                "{CorrelationId} {MRN} Failed to send Decision to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
-                correlationId,
-                mrn,
-                comparerResponse.StatusCode,
-                comparerResponse.ReasonPhrase
-            );
-            throw new ConflictException($"{mrn} Failed to send Decision to Decision Comparer.");
-        }
-
-        if (!comparerResponse.StatusCode.IsSuccessStatusCode())
-        {
-            _logger.Error(
-                "{CorrelationId} {MRN} Failed to send Decision to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
-                correlationId,
-                mrn,
-                comparerResponse.StatusCode,
-                comparerResponse.ReasonPhrase
-            );
-            throw new DecisionComparisonException($"{mrn} Failed to send Decision to Decision Comparer.");
-        }
+        CheckComparerResponse(
+            comparerResponse,
+            $"{correlationId} {mrn} Failed to send Decision to Decision Comparer: Status Code: {comparerResponse.StatusCode}, Reason: {comparerResponse.ReasonPhrase}.",
+            $"{mrn} Failed to send Decision to Decision Comparer."
+        );
 
         var cdsResponse = await ForwardDecisionAsync(
             mrn,

--- a/BtmsGateway/Services/Routing/DecisionSender.cs
+++ b/BtmsGateway/Services/Routing/DecisionSender.cs
@@ -86,13 +86,27 @@ public class DecisionSender : SoapMessageSenderBase, IDecisionSender
 
         if (!comparerResponse.StatusCode.IsSuccessStatusCode())
         {
-            _logger.Error(
-                "{CorrelationId} {MRN} Failed to send Decision to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
-                correlationId,
-                mrn,
-                comparerResponse.StatusCode,
-                comparerResponse.ReasonPhrase
-            );
+            if (comparerResponse.StatusCode == HttpStatusCode.Conflict)
+            {
+                _logger.Warning(
+                    "{CorrelationId} {MRN} Failed to send Decision to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
+                    correlationId,
+                    mrn,
+                    comparerResponse.StatusCode,
+                    comparerResponse.ReasonPhrase
+                );
+            }
+            else
+            {
+                _logger.Error(
+                    "{CorrelationId} {MRN} Failed to send Decision to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
+                    correlationId,
+                    mrn,
+                    comparerResponse.StatusCode,
+                    comparerResponse.ReasonPhrase
+                );
+            }
+
             throw new DecisionComparisonException($"{mrn} Failed to send Decision to Decision Comparer.");
         }
 

--- a/BtmsGateway/Services/Routing/DecisionSender.cs
+++ b/BtmsGateway/Services/Routing/DecisionSender.cs
@@ -98,27 +98,13 @@ public class DecisionSender : SoapMessageSenderBase, IDecisionSender
 
         if (!comparerResponse.StatusCode.IsSuccessStatusCode())
         {
-            if (comparerResponse.StatusCode == HttpStatusCode.Conflict)
-            {
-                _logger.Warning(
-                    "{CorrelationId} {MRN} Failed to send Decision to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
-                    correlationId,
-                    mrn,
-                    comparerResponse.StatusCode,
-                    comparerResponse.ReasonPhrase
-                );
-            }
-            else
-            {
-                _logger.Error(
-                    "{CorrelationId} {MRN} Failed to send Decision to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
-                    correlationId,
-                    mrn,
-                    comparerResponse.StatusCode,
-                    comparerResponse.ReasonPhrase
-                );
-            }
-
+            _logger.Error(
+                "{CorrelationId} {MRN} Failed to send Decision to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
+                correlationId,
+                mrn,
+                comparerResponse.StatusCode,
+                comparerResponse.ReasonPhrase
+            );
             throw new DecisionComparisonException($"{mrn} Failed to send Decision to Decision Comparer.");
         }
 

--- a/BtmsGateway/Services/Routing/DecisionSender.cs
+++ b/BtmsGateway/Services/Routing/DecisionSender.cs
@@ -86,8 +86,9 @@ public class DecisionSender : SoapMessageSenderBase, IDecisionSender
 
         CheckComparerResponse(
             comparerResponse,
-            $"{correlationId} {mrn} Failed to send Decision to Decision Comparer: Status Code: {comparerResponse.StatusCode}, Reason: {comparerResponse.ReasonPhrase}.",
-            $"{mrn} Failed to send Decision to Decision Comparer."
+            correlationId,
+            mrn,
+            "Decision"
         );
 
         var cdsResponse = await ForwardDecisionAsync(

--- a/BtmsGateway/Services/Routing/DecisionSender.cs
+++ b/BtmsGateway/Services/Routing/DecisionSender.cs
@@ -84,29 +84,27 @@ public class DecisionSender : SoapMessageSenderBase, IDecisionSender
             headers
         );
 
+        if (comparerResponse.StatusCode == HttpStatusCode.Conflict)
+        {
+            _logger.Warning(
+                "{CorrelationId} {MRN} Failed to send Decision to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
+                correlationId,
+                mrn,
+                comparerResponse.StatusCode,
+                comparerResponse.ReasonPhrase
+            );
+            throw new ConflictException($"{mrn} Failed to send Decision to Decision Comparer.");
+        }
+
         if (!comparerResponse.StatusCode.IsSuccessStatusCode())
         {
-            if (comparerResponse.StatusCode == HttpStatusCode.Conflict)
-            {
-                _logger.Warning(
-                    "{CorrelationId} {MRN} Failed to send Decision to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
-                    correlationId,
-                    mrn,
-                    comparerResponse.StatusCode,
-                    comparerResponse.ReasonPhrase
-                );
-            }
-            else
-            {
-                _logger.Error(
-                    "{CorrelationId} {MRN} Failed to send Decision to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
-                    correlationId,
-                    mrn,
-                    comparerResponse.StatusCode,
-                    comparerResponse.ReasonPhrase
-                );
-            }
-
+            _logger.Error(
+                "{CorrelationId} {MRN} Failed to send Decision to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
+                correlationId,
+                mrn,
+                comparerResponse.StatusCode,
+                comparerResponse.ReasonPhrase
+            );
             throw new DecisionComparisonException($"{mrn} Failed to send Decision to Decision Comparer.");
         }
 

--- a/BtmsGateway/Services/Routing/DecisionSender.cs
+++ b/BtmsGateway/Services/Routing/DecisionSender.cs
@@ -84,12 +84,7 @@ public class DecisionSender : SoapMessageSenderBase, IDecisionSender
             headers
         );
 
-        CheckComparerResponse(
-            comparerResponse,
-            correlationId,
-            mrn,
-            "Decision"
-        );
+        CheckComparerResponse(comparerResponse, correlationId, mrn, "Decision");
 
         var cdsResponse = await ForwardDecisionAsync(
             mrn,

--- a/BtmsGateway/Services/Routing/ErrorNotificationSender.cs
+++ b/BtmsGateway/Services/Routing/ErrorNotificationSender.cs
@@ -93,13 +93,27 @@ public class ErrorNotificationSender : SoapMessageSenderBase, IErrorNotification
 
         if (!comparerResponse.StatusCode.IsSuccessStatusCode())
         {
-            _logger.Error(
-                "{CorrelationId} {MRN} Failed to send Error Notification to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
-                correlationId,
-                mrn,
-                comparerResponse.StatusCode,
-                comparerResponse.ReasonPhrase
-            );
+            if (comparerResponse.StatusCode == HttpStatusCode.Conflict)
+            {
+                _logger.Warning(
+                    "{CorrelationId} {MRN} Failed to send Error Notification to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
+                    correlationId,
+                    mrn,
+                    comparerResponse.StatusCode,
+                    comparerResponse.ReasonPhrase
+                );
+            }
+            else
+            {
+                _logger.Error(
+                    "{CorrelationId} {MRN} Failed to send Error Notification to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
+                    correlationId,
+                    mrn,
+                    comparerResponse.StatusCode,
+                    comparerResponse.ReasonPhrase
+                );
+            }
+
             throw new DecisionComparisonException($"{mrn} Failed to send Error Notification to Decision Comparer.");
         }
 

--- a/BtmsGateway/Services/Routing/ErrorNotificationSender.cs
+++ b/BtmsGateway/Services/Routing/ErrorNotificationSender.cs
@@ -91,12 +91,7 @@ public class ErrorNotificationSender : SoapMessageSenderBase, IErrorNotification
             headers
         );
 
-        CheckComparerResponse(
-            comparerResponse,
-            correlationId,
-            mrn,
-            "Error Notification"
-        );
+        CheckComparerResponse(comparerResponse, correlationId, mrn, "Error Notification");
 
         // var cdsResponse = await ForwardErrorNotificationAsync(
         //     mrn,

--- a/BtmsGateway/Services/Routing/ErrorNotificationSender.cs
+++ b/BtmsGateway/Services/Routing/ErrorNotificationSender.cs
@@ -91,29 +91,11 @@ public class ErrorNotificationSender : SoapMessageSenderBase, IErrorNotification
             headers
         );
 
-        if (comparerResponse.StatusCode == HttpStatusCode.Conflict)
-        {
-            _logger.Warning(
-                "{CorrelationId} {MRN} Failed to send Error Notification to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
-                correlationId,
-                mrn,
-                comparerResponse.StatusCode,
-                comparerResponse.ReasonPhrase
-            );
-            throw new ConflictException($"{mrn} Failed to send Error Notification to Decision Comparer.");
-        }
-
-        if (!comparerResponse.StatusCode.IsSuccessStatusCode())
-        {
-            _logger.Error(
-                "{CorrelationId} {MRN} Failed to send Error Notification to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
-                correlationId,
-                mrn,
-                comparerResponse.StatusCode,
-                comparerResponse.ReasonPhrase
-            );
-            throw new DecisionComparisonException($"{mrn} Failed to send Error Notification to Decision Comparer.");
-        }
+        CheckComparerResponse(
+            comparerResponse,
+            $"{correlationId} {mrn} Failed to send Error Notification to Decision Comparer: Status Code: {comparerResponse.StatusCode}, Reason: {comparerResponse.ReasonPhrase}.",
+            $"{mrn} Failed to send Error Notification to Decision Comparer."
+        );
 
         // var cdsResponse = await ForwardErrorNotificationAsync(
         //     mrn,

--- a/BtmsGateway/Services/Routing/ErrorNotificationSender.cs
+++ b/BtmsGateway/Services/Routing/ErrorNotificationSender.cs
@@ -105,27 +105,13 @@ public class ErrorNotificationSender : SoapMessageSenderBase, IErrorNotification
 
         if (!comparerResponse.StatusCode.IsSuccessStatusCode())
         {
-            if (comparerResponse.StatusCode == HttpStatusCode.Conflict)
-            {
-                _logger.Warning(
-                    "{CorrelationId} {MRN} Failed to send Error Notification to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
-                    correlationId,
-                    mrn,
-                    comparerResponse.StatusCode,
-                    comparerResponse.ReasonPhrase
-                );
-            }
-            else
-            {
-                _logger.Error(
-                    "{CorrelationId} {MRN} Failed to send Error Notification to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
-                    correlationId,
-                    mrn,
-                    comparerResponse.StatusCode,
-                    comparerResponse.ReasonPhrase
-                );
-            }
-
+            _logger.Error(
+                "{CorrelationId} {MRN} Failed to send Error Notification to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
+                correlationId,
+                mrn,
+                comparerResponse.StatusCode,
+                comparerResponse.ReasonPhrase
+            );
             throw new DecisionComparisonException($"{mrn} Failed to send Error Notification to Decision Comparer.");
         }
 

--- a/BtmsGateway/Services/Routing/ErrorNotificationSender.cs
+++ b/BtmsGateway/Services/Routing/ErrorNotificationSender.cs
@@ -91,29 +91,27 @@ public class ErrorNotificationSender : SoapMessageSenderBase, IErrorNotification
             headers
         );
 
+        if (comparerResponse.StatusCode == HttpStatusCode.Conflict)
+        {
+            _logger.Warning(
+                "{CorrelationId} {MRN} Failed to send Error Notification to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
+                correlationId,
+                mrn,
+                comparerResponse.StatusCode,
+                comparerResponse.ReasonPhrase
+            );
+            throw new ConflictException($"{mrn} Failed to send Error Notification to Decision Comparer.");
+        }
+
         if (!comparerResponse.StatusCode.IsSuccessStatusCode())
         {
-            if (comparerResponse.StatusCode == HttpStatusCode.Conflict)
-            {
-                _logger.Warning(
-                    "{CorrelationId} {MRN} Failed to send Error Notification to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
-                    correlationId,
-                    mrn,
-                    comparerResponse.StatusCode,
-                    comparerResponse.ReasonPhrase
-                );
-            }
-            else
-            {
-                _logger.Error(
-                    "{CorrelationId} {MRN} Failed to send Error Notification to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
-                    correlationId,
-                    mrn,
-                    comparerResponse.StatusCode,
-                    comparerResponse.ReasonPhrase
-                );
-            }
-
+            _logger.Error(
+                "{CorrelationId} {MRN} Failed to send Error Notification to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
+                correlationId,
+                mrn,
+                comparerResponse.StatusCode,
+                comparerResponse.ReasonPhrase
+            );
             throw new DecisionComparisonException($"{mrn} Failed to send Error Notification to Decision Comparer.");
         }
 

--- a/BtmsGateway/Services/Routing/ErrorNotificationSender.cs
+++ b/BtmsGateway/Services/Routing/ErrorNotificationSender.cs
@@ -93,8 +93,9 @@ public class ErrorNotificationSender : SoapMessageSenderBase, IErrorNotification
 
         CheckComparerResponse(
             comparerResponse,
-            $"{correlationId} {mrn} Failed to send Error Notification to Decision Comparer: Status Code: {comparerResponse.StatusCode}, Reason: {comparerResponse.ReasonPhrase}.",
-            $"{mrn} Failed to send Error Notification to Decision Comparer."
+            correlationId,
+            mrn,
+            "Error Notification"
         );
 
         // var cdsResponse = await ForwardErrorNotificationAsync(

--- a/BtmsGateway/Services/Routing/SoapMessageSenderBase.cs
+++ b/BtmsGateway/Services/Routing/SoapMessageSenderBase.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using BtmsGateway.Exceptions;
+using BtmsGateway.Utils;
 using ILogger = Serilog.ILogger;
 
 namespace BtmsGateway.Services.Routing;
@@ -69,5 +70,24 @@ public abstract class SoapMessageSenderBase(IApiSender apiSender, RoutingConfig?
             return await response.Content.ReadAsStringAsync(cancellationToken);
 
         return string.Empty;
+    }
+
+    protected void CheckComparerResponse(
+        HttpResponseMessage comparerResponse,
+        string logMessage,
+        string exceptionMessage
+    )
+    {
+        if (comparerResponse.StatusCode == HttpStatusCode.Conflict)
+        {
+            logger.Warning(logMessage);
+            throw new ConflictException(exceptionMessage);
+        }
+
+        if (!comparerResponse.StatusCode.IsSuccessStatusCode())
+        {
+            logger.Error(logMessage);
+            throw new DecisionComparisonException(exceptionMessage);
+        }
     }
 }

--- a/BtmsGateway/Services/Routing/SoapMessageSenderBase.cs
+++ b/BtmsGateway/Services/Routing/SoapMessageSenderBase.cs
@@ -74,20 +74,35 @@ public abstract class SoapMessageSenderBase(IApiSender apiSender, RoutingConfig?
 
     protected void CheckComparerResponse(
         HttpResponseMessage comparerResponse,
-        string logMessage,
-        string exceptionMessage
+        string? correlationId,
+        string? mrn,
+        string messageType
     )
     {
         if (comparerResponse.StatusCode == HttpStatusCode.Conflict)
         {
-            logger.Warning(logMessage);
-            throw new ConflictException(exceptionMessage);
+            logger.Warning(
+                "{CorrelationId} {MRN} Failed to send {MessageType} to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
+                correlationId,
+                mrn,
+                messageType,
+                comparerResponse.StatusCode,
+                comparerResponse.ReasonPhrase
+            );
+            throw new ConflictException($"{mrn} Failed to send {messageType} to Decision Comparer.");
         }
 
         if (!comparerResponse.StatusCode.IsSuccessStatusCode())
         {
-            logger.Error(logMessage);
-            throw new DecisionComparisonException(exceptionMessage);
+            logger.Error(
+                "{CorrelationId} {MRN} Failed to send {MessageType} to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
+                correlationId,
+                mrn,
+                messageType,
+                comparerResponse.StatusCode,
+                comparerResponse.ReasonPhrase
+            );
+            throw new DecisionComparisonException($"{mrn} Failed to send {messageType} to Decision Comparer.");
         }
     }
 }

--- a/BtmsGateway/Utils/Logging/LoggingInterceptor.cs
+++ b/BtmsGateway/Utils/Logging/LoggingInterceptor.cs
@@ -34,6 +34,7 @@ public class LoggingInterceptor<TMessage>(ILogger<LoggingInterceptor<TMessage>> 
         }
         catch (ConflictException)
         {
+            // Avoiding duplicate logging here as it's already logged at the point where the ConflictException is being thrown
             throw;
         }
         catch (Exception exception)

--- a/BtmsGateway/Utils/Logging/LoggingInterceptor.cs
+++ b/BtmsGateway/Utils/Logging/LoggingInterceptor.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using BtmsGateway.Exceptions;
 using BtmsGateway.Extensions;
 using SlimMessageBus;
 using SlimMessageBus.Host.Interceptor;
@@ -26,6 +27,20 @@ public class LoggingInterceptor<TMessage>(ILogger<LoggingInterceptor<TMessage>> 
             logger.LogWarning(
                 httpRequestException,
                 "409 Conflict processing message {MessageId} for resource {ResourceId}",
+                messageId,
+                resourceId
+            );
+            throw;
+        }
+        catch (ConflictException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(
+                exception,
+                "Error processing message {MessageId} for resource {ResourceId}",
                 messageId,
                 resourceId
             );

--- a/BtmsGateway/Utils/Logging/LoggingInterceptor.cs
+++ b/BtmsGateway/Utils/Logging/LoggingInterceptor.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using BtmsGateway.Exceptions;
 using BtmsGateway.Extensions;
 using SlimMessageBus;
 using SlimMessageBus.Host.Interceptor;
@@ -26,6 +27,16 @@ public class LoggingInterceptor<TMessage>(ILogger<LoggingInterceptor<TMessage>> 
             logger.LogWarning(
                 httpRequestException,
                 "409 Conflict processing message {MessageId} for resource {ResourceId}",
+                messageId,
+                resourceId
+            );
+            throw;
+        }
+        catch (ConflictException conflictException)
+        {
+            logger.LogWarning(
+                conflictException,
+                "Error processing message {MessageId} for resource {ResourceId}",
                 messageId,
                 resourceId
             );

--- a/BtmsGateway/Utils/Logging/LoggingInterceptor.cs
+++ b/BtmsGateway/Utils/Logging/LoggingInterceptor.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
-using BtmsGateway.Exceptions;
 using BtmsGateway.Extensions;
 using SlimMessageBus;
 using SlimMessageBus.Host.Interceptor;
@@ -27,26 +26,6 @@ public class LoggingInterceptor<TMessage>(ILogger<LoggingInterceptor<TMessage>> 
             logger.LogWarning(
                 httpRequestException,
                 "409 Conflict processing message {MessageId} for resource {ResourceId}",
-                messageId,
-                resourceId
-            );
-            throw;
-        }
-        catch (ConflictException conflictException)
-        {
-            logger.LogWarning(
-                conflictException,
-                "Error processing message {MessageId} for resource {ResourceId}",
-                messageId,
-                resourceId
-            );
-            throw;
-        }
-        catch (Exception exception)
-        {
-            logger.LogError(
-                exception,
-                "Error processing message {MessageId} for resource {ResourceId}",
                 messageId,
                 resourceId
             );


### PR DESCRIPTION
- Throws custom exception when a 409 conflict occurs so that it can be caught and logged as warning as the exception is bubbled up
- Refactoring to satisfy sonar