### PR TITLE
CDMS-808: return SOAP failure responses

### DIFF
--- a/BtmsGateway.Test/Services/Converter/SoapContentTests.cs
+++ b/BtmsGateway.Test/Services/Converter/SoapContentTests.cs
@@ -1,3 +1,4 @@
+using BtmsGateway.Exceptions;
 using BtmsGateway.Services.Converter;
 using FluentAssertions;
 
@@ -146,5 +147,15 @@ public class SoapContentTests
         soapContent
             .SoapString.Should()
             .Contain("<GoodsDescription>XML Character Entities &quot; &apos; &lt; &gt; &amp;</GoodsDescription>");
+    }
+
+    [Fact]
+    public void When_soap_is_unparsable_Then_invalid_soap_exception_should_be_thrown()
+    {
+        const string soap = $"{Declaration}<Envelope><Body><Message1><Data>&</Data></Message1></Body></Envelope>";
+
+        var thrownException = Assert.Throws<InvalidSoapException>(() => new SoapContent(soap));
+        thrownException.Message.Should().Be("Invalid SOAP Message");
+        thrownException.InnerException.Should().NotBeNull();
     }
 }

--- a/BtmsGateway.Test/Services/Converter/SoapToJsonConverterTests.cs
+++ b/BtmsGateway.Test/Services/Converter/SoapToJsonConverterTests.cs
@@ -1,3 +1,4 @@
+using BtmsGateway.Exceptions;
 using BtmsGateway.Services.Converter;
 using BtmsGateway.Test.TestUtils;
 using FluentAssertions;
@@ -48,7 +49,7 @@ public class SoapToJsonConverterTests
     {
         var soapContent = new SoapContent(File.ReadAllText(Path.Combine(TestDataPath, "ClearanceRequestSoap.xml")));
 
-        var thrownException = Assert.Throws<ArgumentException>(() =>
+        var thrownException = Assert.Throws<InvalidSoapException>(() =>
             SoapToJsonConverter.Convert(soapContent, "NonExistingMessageSubPath")
         );
         thrownException.Message.Should().Be("The XML message is not valid");

--- a/BtmsGateway.Test/Services/Routing/MessageRoutesTests.cs
+++ b/BtmsGateway.Test/Services/Routing/MessageRoutesTests.cs
@@ -173,4 +173,16 @@ public class MessageRoutesTests
             .WithInnerException<InvalidDataException>()
             .WithMessage("Invalid Link Type in config");
     }
+
+    [Theory]
+    [InlineData("/route/path-1/sub/path", true)]
+    [InlineData("/route/path-2/sub/path", false)]
+    [InlineData("/foo", false)]
+    [InlineData("/foo/", false)]
+    public void When_checking_for_cds_route_Then_should_return_expected(string routePath, bool expectedResult)
+    {
+        var messageRoutes = new MessageRoutes(TestRoutes.CdsDefinedRoutes, Substitute.For<ILogger>());
+
+        messageRoutes.IsCdsRoute(routePath).Should().Be(expectedResult);
+    }
 }

--- a/BtmsGateway.Test/Services/Routing/QueueSenderTests.cs
+++ b/BtmsGateway.Test/Services/Routing/QueueSenderTests.cs
@@ -1,10 +1,13 @@
 using System.Net;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
+using BtmsGateway.Exceptions;
+using BtmsGateway.Services.Converter;
 using BtmsGateway.Services.Routing;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Serilog;
 
 namespace BtmsGateway.Test.Services.Routing;
@@ -29,7 +32,7 @@ public class QueueSenderTests
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         response.RoutingSuccessful.Should().BeFalse();
-        response.ResponseContent.Should().Contain("Failed to publish message to inbound topic");
+        response.ResponseContent.Should().Contain(SoapUtils.FailedSoapRequestResponseBody);
     }
 
     [Fact]
@@ -63,7 +66,7 @@ public class QueueSenderTests
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         response.RoutingSuccessful.Should().BeFalse();
-        response.ResponseContent.Should().Contain("Failed to publish message to inbound topic");
+        response.ResponseContent.Should().Contain(SoapUtils.FailedSoapRequestResponseBody);
     }
 
     [Fact]
@@ -98,6 +101,46 @@ public class QueueSenderTests
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.RoutingSuccessful.Should().BeTrue();
         response.ResponseContent.Should().Contain("<StatusCode>000</StatusCode>");
+    }
+
+    [Fact]
+    public async Task SendAsync_Throws_InvalidSoapException_Then_ReturnsErrorResult()
+    {
+        // Arrange
+        var mockSnsService = Substitute.For<IAmazonSimpleNotificationService>();
+        mockSnsService
+            .PublishAsync(Arg.Any<PublishRequest>())
+            .ThrowsAsync(new InvalidSoapException("Test", new Exception("Inner Exception")));
+        var mockLogger = Substitute.For<ILogger>();
+        var msgData = await TestHelpers.CreateMessageData(mockLogger);
+        var sut = new QueueSender(mockSnsService, config, mockLogger);
+
+        // Act
+        var response = await sut.Send(msgData.Routing, msgData.MessageData, "");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.RoutingSuccessful.Should().BeFalse();
+        response.ResponseContent.Should().Contain(SoapUtils.FailedSoapRequestResponseBody);
+    }
+
+    [Fact]
+    public async Task SendAsync_Throws_GeneralException_Then_ReturnsErrorResult()
+    {
+        // Arrange
+        var mockSnsService = Substitute.For<IAmazonSimpleNotificationService>();
+        mockSnsService.PublishAsync(Arg.Any<PublishRequest>()).ThrowsAsync(new Exception("Test"));
+        var mockLogger = Substitute.For<ILogger>();
+        var msgData = await TestHelpers.CreateMessageData(mockLogger);
+        var sut = new QueueSender(mockSnsService, config, mockLogger);
+
+        // Act
+        var response = await sut.Send(msgData.Routing, msgData.MessageData, "");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        response.RoutingSuccessful.Should().BeFalse();
+        response.ResponseContent.Should().Contain(SoapUtils.FailedSoapRequestResponseBody);
     }
 
     private static (IAmazonSimpleNotificationService SnsService, ILogger Logger) CreateMocks(

--- a/BtmsGateway.Test/Services/Routing/TestRoutes.cs
+++ b/BtmsGateway.Test/Services/Routing/TestRoutes.cs
@@ -304,4 +304,49 @@ public static class TestRoutes
             },
         },
     };
+
+    public static readonly RoutingConfig CdsDefinedRoutes = new()
+    {
+        NamedRoutes = new Dictionary<string, NamedRoute>
+        {
+            {
+                "cds-route",
+                new NamedRoute
+                {
+                    RoutePath = "/route/path-1/sub/path",
+                    Legend = "Route 1",
+                    LegacyLinkName = "none",
+                    BtmsLinkName = "none",
+                    MessageSubXPath = "Message1",
+                    RouteTo = RouteTo.Legacy,
+                    IsCds = true,
+                }
+            },
+            {
+                "some-other-route",
+                new NamedRoute
+                {
+                    RoutePath = "/route/path-2/sub/path",
+                    Legend = "Route 2",
+                    LegacyLinkName = "none",
+                    BtmsLinkName = "none",
+                    MessageSubXPath = "Message2",
+                    RouteTo = RouteTo.Legacy,
+                }
+            },
+        },
+        NamedLinks = new Dictionary<string, NamedLink>
+        {
+            {
+                "none",
+                new NamedLink
+                {
+                    Link = "none",
+                    LinkType = LinkType.None,
+                    HostHeader = null,
+                }
+            },
+        },
+        Destinations = new Dictionary<string, Destination>(),
+    };
 }

--- a/BtmsGateway/Domain/Features.cs
+++ b/BtmsGateway/Domain/Features.cs
@@ -4,4 +4,5 @@ public static class Features
 {
     public const string SendOnlyBtmsDecisionToCds = nameof(SendOnlyBtmsDecisionToCds);
     public const string SendOnlyBtmsErrorNotificationToCds = nameof(SendOnlyBtmsErrorNotificationToCds);
+    public const string Cutover = nameof(Cutover);
 }

--- a/BtmsGateway/Domain/MessagingConstants.cs
+++ b/BtmsGateway/Domain/MessagingConstants.cs
@@ -70,14 +70,4 @@ public static class MessagingConstants
         public const string BtmsOutboundErrors = "BtmsOutboundErrors";
         public const string AlvsOutboundErrors = "AlvsOutboundErrors";
     }
-
-    public static class Routes
-    {
-        public static string[] CdsRoutes =
-        [
-            "CDSClearanceRequestToAlvs",
-            "CDSFinalisationNotificationToAlvs",
-            "CDSErrorNotificationToAlvs",
-        ];
-    }
 }

--- a/BtmsGateway/Domain/MessagingConstants.cs
+++ b/BtmsGateway/Domain/MessagingConstants.cs
@@ -70,4 +70,14 @@ public static class MessagingConstants
         public const string BtmsOutboundErrors = "BtmsOutboundErrors";
         public const string AlvsOutboundErrors = "AlvsOutboundErrors";
     }
+
+    public static class Routes
+    {
+        public static string[] CdsRoutes =
+        [
+            "CDSClearanceRequestToAlvs",
+            "CDSFinalisationNotificationToAlvs",
+            "CDSErrorNotificationToAlvs",
+        ];
+    }
 }

--- a/BtmsGateway/Exceptions/InvalidSoapException.cs
+++ b/BtmsGateway/Exceptions/InvalidSoapException.cs
@@ -1,0 +1,3 @@
+namespace BtmsGateway.Exceptions;
+
+public class InvalidSoapException(string message, Exception inner) : Exception(message, inner);

--- a/BtmsGateway/Middleware/RoutingInterceptor.cs
+++ b/BtmsGateway/Middleware/RoutingInterceptor.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Text;
 using BtmsGateway.Config;
@@ -12,6 +13,7 @@ using ILogger = Serilog.ILogger;
 
 namespace BtmsGateway.Middleware;
 
+[SuppressMessage("SonarLint", "S107", Justification = "Parameters will be reduced once the feature flag is removed")]
 public class RoutingInterceptor(
     RequestDelegate next,
     IMessageRouter messageRouter,

--- a/BtmsGateway/Middleware/RoutingInterceptor.cs
+++ b/BtmsGateway/Middleware/RoutingInterceptor.cs
@@ -68,6 +68,8 @@ public class RoutingInterceptor(
         {
             if (await featureManager.IsEnabledAsync(Features.Cutover) && messageRoutes.IsCdsRoute(context.Request.Path))
             {
+                // Log as Warning as we won't do anything with it at this point, and we don't want additional errors causing potential alerts.
+                // The upstream system needs to sort out the invalid request
                 logger.Warning(ex, "Invalid SOAP Message");
                 await PopulateInvalidSoapResponse(context);
                 throw new RoutingException("Invalid SOAP Message", ex);

--- a/BtmsGateway/Services/Converter/SoapContent.cs
+++ b/BtmsGateway/Services/Converter/SoapContent.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Xml;
+using BtmsGateway.Exceptions;
 
 namespace BtmsGateway.Services.Converter;
 
@@ -20,10 +21,17 @@ public class SoapContent
 
     public SoapContent(string? soapString)
     {
-        SoapString = GetDecodedString(soapString);
-        RawSoapString = soapString;
-        var soapXmlNode = GetElement(SoapString);
-        _soapXmlNode = soapXmlNode;
+        try
+        {
+            SoapString = GetDecodedString(soapString);
+            RawSoapString = soapString;
+            var soapXmlNode = GetElement(SoapString);
+            _soapXmlNode = soapXmlNode;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidSoapException("Invalid SOAP Message", ex);
+        }
     }
 
     public bool HasMessage(string messageSubXPath)

--- a/BtmsGateway/Services/Converter/SoapToJsonConverter.cs
+++ b/BtmsGateway/Services/Converter/SoapToJsonConverter.cs
@@ -1,4 +1,5 @@
 using System.Xml.Linq;
+using BtmsGateway.Exceptions;
 
 namespace BtmsGateway.Services.Converter;
 
@@ -25,7 +26,7 @@ public static class SoapToJsonConverter
         }
         catch (Exception ex)
         {
-            throw new ArgumentException("The XML message is not valid", ex);
+            throw new InvalidSoapException("The XML message is not valid", ex);
         }
     }
 }

--- a/BtmsGateway/Services/Converter/SoapUtils.cs
+++ b/BtmsGateway/Services/Converter/SoapUtils.cs
@@ -33,6 +33,10 @@ public static class SoapUtils
     private static string SuccessfulAlvsErrorNotificationResponseBody =>
         "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n\t<soapenv:Body>\n\t\t<ALVSErrorNotificationResponse xmlns=\"http://alvserrornotification.types.esb.ws.cara.defra.com\" xmlns:ns2=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\" xmlns:ns3=\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\">\n\t\t\t<StatusCode>000</StatusCode>\n\t\t</ALVSErrorNotificationResponse>\n\t</soapenv:Body>\n</soapenv:Envelope>";
 
+    //HMRC requests failure responses
+    public static string FailedSoapRequestResponseBody =>
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">\n\t<soapenv:Body>\n\t\t<soapenv:Fault>\n\t\t\t<soapenv:Code>\n\t\t\t\t<soapenv:Value>soapenv:Receiver</soapenv:Value>\n\t\t\t</soapenv:Code>\n\t\t\t<soapenv:Reason>\n\t\t\t\t<soapenv:Text xml:lang=\"en\">A soap fault was returned.</soapenv:Text>\n\t\t\t</soapenv:Reason>\n\t\t</soapenv:Fault>\n\t</soapenv:Body>\n</soapenv:Envelope>";
+
     public static XElement AddSoapEnvelope(XElement rootElement, SoapType soapType)
     {
         return soapType switch

--- a/BtmsGateway/Services/Routing/DecisionSender.cs
+++ b/BtmsGateway/Services/Routing/DecisionSender.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using BtmsGateway.Domain;
 using BtmsGateway.Exceptions;
-using BtmsGateway.Utils;
 using Microsoft.FeatureManagement;
 using ILogger = Serilog.ILogger;
 

--- a/BtmsGateway/Services/Routing/ErrorNotificationSender.cs
+++ b/BtmsGateway/Services/Routing/ErrorNotificationSender.cs
@@ -2,7 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using BtmsGateway.Domain;
 using BtmsGateway.Exceptions;
-using BtmsGateway.Utils;
 using Microsoft.FeatureManagement;
 using ILogger = Serilog.ILogger;
 

--- a/BtmsGateway/Services/Routing/MessageRoutes.cs
+++ b/BtmsGateway/Services/Routing/MessageRoutes.cs
@@ -81,11 +81,9 @@ public class MessageRoutes : IMessageRoutes
 
     public bool IsCdsRoute(string routePath)
     {
-        var route = _routes.FirstOrDefault(x =>
-            x.RoutePath.Equals(routePath.Trim('/'), StringComparison.InvariantCultureIgnoreCase)
+        return _routes.Any(x =>
+            x.IsCds && x.RoutePath.Equals(routePath.Trim('/'), StringComparison.InvariantCultureIgnoreCase)
         );
-
-        return MessagingConstants.Routes.CdsRoutes.Contains(route?.Name);
     }
 
     private static RoutingResult SelectRoute(RoutedLink route, string routePath)

--- a/BtmsGateway/Services/Routing/MessageRoutes.cs
+++ b/BtmsGateway/Services/Routing/MessageRoutes.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using BtmsGateway.Domain;
 using BtmsGateway.Exceptions;
 using BtmsGateway.Services.Converter;
 using ILogger = Serilog.ILogger;
@@ -9,6 +10,7 @@ namespace BtmsGateway.Services.Routing;
 public interface IMessageRoutes
 {
     RoutingResult GetRoute(string routePath, SoapContent soapContent, string? correlationId, string? mrn);
+    bool IsCdsRoute(string routePath);
 }
 
 public class MessageRoutes : IMessageRoutes
@@ -75,6 +77,15 @@ public class MessageRoutes : IMessageRoutes
                 ErrorMessage = $"Error getting route - {ex.Message} - {ex.InnerException?.Message}",
             };
         }
+    }
+
+    public bool IsCdsRoute(string routePath)
+    {
+        var route = _routes.FirstOrDefault(x =>
+            x.RoutePath.Equals(routePath.Trim('/'), StringComparison.InvariantCultureIgnoreCase)
+        );
+
+        return MessagingConstants.Routes.CdsRoutes.Contains(route?.Name);
     }
 
     private static RoutingResult SelectRoute(RoutedLink route, string routePath)

--- a/BtmsGateway/Services/Routing/QueueSender.cs
+++ b/BtmsGateway/Services/Routing/QueueSender.cs
@@ -59,7 +59,7 @@ public class QueueSender(IAmazonSimpleNotificationService snsService, IConfigura
                 messageData.ContentMap.CorrelationId,
                 messageData.ContentMap.MessageReference
             );
-            return RoutingResultWithStatusCode(routingResult, HttpStatusCode.BadGateway);
+            return RoutingResultWithStatusCode(routingResult, HttpStatusCode.BadRequest);
         }
         catch (Exception ex)
         {
@@ -74,7 +74,7 @@ public class QueueSender(IAmazonSimpleNotificationService snsService, IConfigura
         }
     }
 
-    private RoutingResult RoutingResultWithStatusCode(RoutingResult routingResult, HttpStatusCode statusCode)
+    private static RoutingResult RoutingResultWithStatusCode(RoutingResult routingResult, HttpStatusCode statusCode)
     {
         return routingResult with
         {

--- a/BtmsGateway/Services/Routing/QueueSender.cs
+++ b/BtmsGateway/Services/Routing/QueueSender.cs
@@ -1,4 +1,6 @@
+using System.Net;
 using Amazon.SimpleNotificationService;
+using BtmsGateway.Exceptions;
 using BtmsGateway.Middleware;
 using BtmsGateway.Services.Converter;
 using BtmsGateway.Utils;
@@ -16,39 +18,69 @@ public class QueueSender(IAmazonSimpleNotificationService snsService, IConfigura
 {
     public async Task<RoutingResult> Send(RoutingResult routingResult, MessageData messageData, string? route)
     {
-        var traceIdHeader = configuration.GetValue<string>("TraceHeader");
-        var request = messageData.CreatePublishRequest(route, routingResult.MessageSubXPath, traceIdHeader);
-
-        var response = await snsService.PublishAsync(request);
-
-        if (response.HttpStatusCode.IsSuccessStatusCode())
+        try
         {
-            logger.Information(
-                "{ContentCorrelationId} {MessageReference} Successfully published MessageId: {MessageId}",
+            var traceIdHeader = configuration.GetValue<string>("TraceHeader");
+
+            var request = messageData.CreatePublishRequest(route, routingResult.MessageSubXPath, traceIdHeader);
+
+            var response = await snsService.PublishAsync(request);
+
+            if (response.HttpStatusCode.IsSuccessStatusCode())
+            {
+                logger.Information(
+                    "{ContentCorrelationId} {MessageReference} Successfully published MessageId: {MessageId}",
+                    messageData.ContentMap.CorrelationId,
+                    messageData.ContentMap.MessageReference,
+                    response.MessageId
+                );
+
+                return routingResult with
+                {
+                    RoutingSuccessful = true,
+                    ResponseContent = SoapUtils.GetMessageTypeSuccessResponse(routingResult.MessageSubXPath),
+                    StatusCode = response.HttpStatusCode,
+                };
+            }
+
+            logger.Error(
+                "{ContentCorrelationId} {MessageReference} Failed to publish message to inbound topic",
                 messageData.ContentMap.CorrelationId,
-                messageData.ContentMap.MessageReference,
-                response.MessageId
+                messageData.ContentMap.MessageReference
             );
 
-            return routingResult with
-            {
-                RoutingSuccessful = true,
-                ResponseContent = SoapUtils.GetMessageTypeSuccessResponse(routingResult.MessageSubXPath),
-                StatusCode = response.HttpStatusCode,
-            };
+            return RoutingResultWithStatusCode(routingResult, response.HttpStatusCode);
         }
+        catch (InvalidSoapException ex)
+        {
+            logger.Warning(
+                ex,
+                "{ContentCorrelationId} {MessageReference} Invalid SOAP message",
+                messageData.ContentMap.CorrelationId,
+                messageData.ContentMap.MessageReference
+            );
+            return RoutingResultWithStatusCode(routingResult, HttpStatusCode.BadGateway);
+        }
+        catch (Exception ex)
+        {
+            logger.Error(
+                ex,
+                "{ContentCorrelationId} {MessageReference} Failed to publish message to inbound topic",
+                messageData.ContentMap.CorrelationId,
+                messageData.ContentMap.MessageReference
+            );
 
-        logger.Error(
-            "{ContentCorrelationId} {MessageReference} Failed to publish message to inbound topic",
-            messageData.ContentMap.CorrelationId,
-            messageData.ContentMap.MessageReference
-        );
+            return RoutingResultWithStatusCode(routingResult, HttpStatusCode.InternalServerError);
+        }
+    }
 
+    private RoutingResult RoutingResultWithStatusCode(RoutingResult routingResult, HttpStatusCode statusCode)
+    {
         return routingResult with
         {
             RoutingSuccessful = false,
-            ResponseContent = "Failed to publish message to inbound topic",
-            StatusCode = response.HttpStatusCode,
+            ResponseContent = SoapUtils.FailedSoapRequestResponseBody,
+            StatusCode = statusCode,
         };
     }
 }

--- a/BtmsGateway/Services/Routing/RoutingConfig.cs
+++ b/BtmsGateway/Services/Routing/RoutingConfig.cs
@@ -23,6 +23,7 @@ public record RoutingConfig
                     nr.Value.MessageSubXPath,
                     nr.Value.Legend,
                     nr.Value.RouteTo,
+                    nr.Value.IsCds,
                 }
         );
         var btms = NamedRoutes.Join(
@@ -40,6 +41,7 @@ public record RoutingConfig
                     nr.Value.MessageSubXPath,
                     nr.Value.Legend,
                     nr.Value.RouteTo,
+                    nr.Value.IsCds,
                 }
         );
         var output = legacy
@@ -61,6 +63,7 @@ public record RoutingConfig
                         RoutePath = l.RoutePath.Trim('/'),
                         MessageSubXPath = l.MessageSubXPath,
                         RouteTo = b.RouteTo,
+                        IsCds = b.IsCds,
                     }
             )
             .ToArray();
@@ -81,6 +84,7 @@ public record NamedRoute
     public string? LegacyLinkName { get; init; }
     public string? BtmsLinkName { get; init; }
     public required RouteTo RouteTo { get; init; }
+    public bool IsCds { get; init; }
 }
 
 public record NamedLink
@@ -122,6 +126,7 @@ public record RoutedLink
     public required LinkType BtmsLinkType { get; init; }
     public string? BtmsHostHeader { get; init; }
     public required RouteTo RouteTo { get; init; }
+    public required bool IsCds { get; init; }
 }
 
 public enum RouteTo

--- a/BtmsGateway/appsettings.json
+++ b/BtmsGateway/appsettings.json
@@ -37,7 +37,8 @@
         "Legend": "Customs Clearance Request",
         "LegacyLinkName": "Stub",
         "BtmsLinkName": "InboundCustomsDeclarationReceivedTopic",
-        "RouteTo": "Legacy"
+        "RouteTo": "Legacy",
+        "IsCds": true
       },
       "CDSFinalisationNotificationToAlvs": {
         "RoutePath": "/ITSW/CDS/NotifyFinalisedStateCDSFacadeService",
@@ -45,7 +46,8 @@
         "Legend": "Customs Finalisation",
         "LegacyLinkName": "Stub",
         "BtmsLinkName": "InboundCustomsDeclarationReceivedTopic",
-        "RouteTo": "Legacy"
+        "RouteTo": "Legacy",
+        "IsCds": true
       },
       "CDSErrorNotificationToAlvs": {
         "RoutePath": "/ITSW/CDS/ALVSCDSErrorNotificationService",
@@ -53,7 +55,8 @@
         "Legend": "Customs Error",
         "LegacyLinkName": "Stub",
         "BtmsLinkName": "InboundCustomsDeclarationReceivedTopic",
-        "RouteTo": "Legacy"
+        "RouteTo": "Legacy",
+        "IsCds": true
       },
       "ALVSDecisionNotificationToCds": {
         "RoutePath": "/ws/CDS/defra/alvsclearanceinbound/v1",


### PR DESCRIPTION
- Checks for SOAP exceptions in requests sent from CDS and returns a relevant SOAP response during cutover phase, otherwise returns whatever it is currently returning
- Also checks for failures to publish to the inbound SNS Topic and returns a relevant SOAP response during cutover phase