### PR TITLE
CDMS-978: provides a positive response to ALVS IPAFFS requests that are routed to None and discarded.

### DIFF
--- a/BtmsGateway/Services/Routing/MessageRoutes.cs
+++ b/BtmsGateway/Services/Routing/MessageRoutes.cs
@@ -104,6 +104,7 @@ public class MessageRoutes : IMessageRoutes
                 ForkHostHeader = route.BtmsHostHeader,
                 ConvertForkedContentToFromJson = true,
                 UrlPath = routePath,
+                StatusCode = route.LegacyLinkType == LinkType.None ? HttpStatusCode.Accepted : default,
             },
             RouteTo.Btms => new RoutingResult
             {
@@ -119,6 +120,7 @@ public class MessageRoutes : IMessageRoutes
                 ForkHostHeader = route.LegacyHostHeader,
                 ConvertRoutedContentToFromJson = true,
                 UrlPath = routePath,
+                StatusCode = route.BtmsLinkType == LinkType.None ? HttpStatusCode.Accepted : default,
             },
             _ => throw new ArgumentOutOfRangeException(
                 nameof(route),


### PR DESCRIPTION
- Provides a default response to requests that are configured to be routed to 'None' (the discard route)