### PR TITLE
BAU: Fix healthcheck port for the gateway

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -46,7 +46,7 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Development
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:3091/health" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
The healthcheck port was incorrect in the compose file.