### PR TITLE
CDMS-1013: fix log templating where correlation id is used

### DIFF
--- a/BtmsGateway/Services/Routing/DecisionSender.cs
+++ b/BtmsGateway/Services/Routing/DecisionSender.cs
@@ -56,7 +56,7 @@ public class DecisionSender : SoapMessageSenderBase, IDecisionSender
     )
     {
         _logger.Debug(
-            "{CorrelationId} {MRN} Sending decision from {MessageSource} to Decision Comparer.",
+            "{MessageCorrelationId} {MRN} Sending decision from {MessageSource} to Decision Comparer.",
             correlationId,
             mrn,
             messageSource
@@ -117,7 +117,7 @@ public class DecisionSender : SoapMessageSenderBase, IDecisionSender
         if (messageSource == await MessageSourceToSend())
         {
             _logger.Debug(
-                "{CorrelationId} {MRN} Sending Decision received from Decision Comparer to CDS.",
+                "{MessageCorrelationId} {MRN} Sending Decision received from Decision Comparer to CDS.",
                 correlationId,
                 mrn
             );
@@ -127,7 +127,7 @@ public class DecisionSender : SoapMessageSenderBase, IDecisionSender
             if (string.IsNullOrWhiteSpace(comparerDecision))
             {
                 _logger.Error(
-                    "{CorrelationId} {MRN} Decision Comparer returned an invalid decision",
+                    "{MessageCorrelationId} {MRN} Decision Comparer returned an invalid decision",
                     correlationId,
                     mrn
                 );
@@ -147,7 +147,7 @@ public class DecisionSender : SoapMessageSenderBase, IDecisionSender
             if (!response.IsSuccessStatusCode)
             {
                 _logger.Error(
-                    "{CorrelationId} {MRN} Failed to send Decision to CDS. CDS Response Status Code: {StatusCode}, Reason: {Reason}, Content: {Content}",
+                    "{MessageCorrelationId} {MRN} Failed to send Decision to CDS. CDS Response Status Code: {StatusCode}, Reason: {Reason}, Content: {Content}",
                     contentMap.CorrelationId,
                     mrn,
                     response.StatusCode,
@@ -158,7 +158,7 @@ public class DecisionSender : SoapMessageSenderBase, IDecisionSender
             }
 
             _logger.Information(
-                "{CorrelationId} {MRN} Successfully sent Decision to CDS.",
+                "{MessageCorrelationId} {MRN} Successfully sent Decision to CDS.",
                 contentMap.CorrelationId,
                 mrn
             );
@@ -166,7 +166,7 @@ public class DecisionSender : SoapMessageSenderBase, IDecisionSender
             return response;
         }
 
-        _logger.Information("{CorrelationId} {MRN} Successfully sent Decision to NOOP.", correlationId, mrn);
+        _logger.Information("{MessageCorrelationId} {MRN} Successfully sent Decision to NOOP.", correlationId, mrn);
 
         return null;
     }

--- a/BtmsGateway/Services/Routing/ErrorNotificationSender.cs
+++ b/BtmsGateway/Services/Routing/ErrorNotificationSender.cs
@@ -54,7 +54,7 @@ public class ErrorNotificationSender : SoapMessageSenderBase, IErrorNotification
     )
     {
         _logger.Debug(
-            "{CorrelationId} {MRN} Sending error notification from {MessageSource} to Decision Comparer.",
+            "{MessageCorrelationId} {MRN} Sending error notification from {MessageSource} to Decision Comparer.",
             correlationId,
             mrn,
             messageSource
@@ -116,7 +116,7 @@ public class ErrorNotificationSender : SoapMessageSenderBase, IErrorNotification
         if (messageSource == await MessageSourceToSend())
         {
             _logger.Debug(
-                "{CorrelationId} {MRN} Sending {MessageSource} Error Notification to CDS.",
+                "{MessageCorrelationId} {MRN} Sending {MessageSource} Error Notification to CDS.",
                 correlationId,
                 mrn,
                 messageSource
@@ -132,7 +132,7 @@ public class ErrorNotificationSender : SoapMessageSenderBase, IErrorNotification
             if (!response.IsSuccessStatusCode)
             {
                 _logger.Error(
-                    "{CorrelationId} {MRN} Failed to send error notification to CDS. CDS Response Status Code: {StatusCode}, Reason: {Reason}, Content: {Content}",
+                    "{MessageCorrelationId} {MRN} Failed to send error notification to CDS. CDS Response Status Code: {StatusCode}, Reason: {Reason}, Content: {Content}",
                     correlationId,
                     mrn,
                     response.StatusCode,
@@ -143,7 +143,7 @@ public class ErrorNotificationSender : SoapMessageSenderBase, IErrorNotification
             }
 
             _logger.Information(
-                "{CorrelationId} {MRN} Successfully sent {MessageSource} Error Notification to CDS.",
+                "{MessageCorrelationId} {MRN} Successfully sent {MessageSource} Error Notification to CDS.",
                 correlationId,
                 mrn,
                 messageSource
@@ -153,7 +153,7 @@ public class ErrorNotificationSender : SoapMessageSenderBase, IErrorNotification
         }
 
         _logger.Information(
-            "{CorrelationId} {MRN} {MessageSource} Error Notification sent to NOOP.",
+            "{MessageCorrelationId} {MRN} {MessageSource} Error Notification sent to NOOP.",
             correlationId,
             mrn,
             messageSource

--- a/BtmsGateway/Services/Routing/SoapMessageSenderBase.cs
+++ b/BtmsGateway/Services/Routing/SoapMessageSenderBase.cs
@@ -89,7 +89,7 @@ public abstract class SoapMessageSenderBase(
         if (comparerResponse.StatusCode == HttpStatusCode.Conflict)
         {
             logger.Warning(
-                "{CorrelationId} {MRN} Failed to send {MessageType} to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
+                "{MessageCorrelationId} {MRN} Failed to send {MessageType} to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
                 correlationId,
                 mrn,
                 messageType,
@@ -102,7 +102,7 @@ public abstract class SoapMessageSenderBase(
         if (!comparerResponse.StatusCode.IsSuccessStatusCode())
         {
             logger.Error(
-                "{CorrelationId} {MRN} Failed to send {MessageType} to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
+                "{MessageCorrelationId} {MRN} Failed to send {MessageType} to Decision Comparer: Status Code: {ComparerResponseStatusCode}, Reason: {ComparerResponseReason}.",
                 correlationId,
                 mrn,
                 messageType,


### PR DESCRIPTION
- In the message Consumers, when the template field 'CorrelationId' is used in a log message template, it was being replaced by the TraceContextEnricher with the Trace ID. This fix uses a different template field to avoid the clash.