### PR TITLE
CDMS-1058: uses http client with a longer timeout for specifically configured routes (ALVS to IPAFFS search requests)

### DIFF
--- a/BtmsGateway/Config/ConfigureServices.cs
+++ b/BtmsGateway/Config/ConfigureServices.cs
@@ -17,6 +17,7 @@ public static class ConfigureServices
     public static IHttpClientBuilder? HttpForkedClientWithRetryBuilder { get; private set; }
     public static IHttpClientBuilder? HttpClientWithRetryBuilder { get; private set; }
     public static IHttpClientBuilder? DecisionComparerHttpClientWithRetryBuilder { get; private set; }
+    public static IHttpClientBuilder? AlvsIpaffsHttpClientWithRetryBuilder { get; private set; }
 
     [ExcludeFromCodeCoverage]
     public static void AddServices(this WebApplicationBuilder builder, ILogger? logger = null)
@@ -40,6 +41,10 @@ public static class ConfigureServices
             "HttpClientTimeoutSeconds",
             Proxy.DefaultHttpClientTimeoutSeconds
         );
+        var alvsIpaffsHttpClientTimeoutSeconds = builder.Configuration.GetValue(
+            "AlvsIpaffsHttpClientTimeoutSeconds",
+            Proxy.DefaultAlvsIpaffsHttpClientTimeoutSeconds
+        );
         var cdsHttpClientRetries = builder.Configuration.GetValue(
             "CdsHttpClientRetries",
             Proxy.DefaultCdsHttpClientRetries
@@ -53,6 +58,10 @@ public static class ConfigureServices
         );
         DecisionComparerHttpClientWithRetryBuilder = builder.Services.AddDecisionComparerHttpProxyClientWithRetry(
             httpClientTimeoutSeconds
+        );
+        AlvsIpaffsHttpClientWithRetryBuilder = builder.Services.AddHttpProxyRoutedClientWithRetry(
+            alvsIpaffsHttpClientTimeoutSeconds,
+            Proxy.AlvsIpaffsProxyClientWithRetry
         );
 
         builder.Services.AddHttpProxyClientWithoutRetry();

--- a/BtmsGateway/Services/Routing/ApiSender.cs
+++ b/BtmsGateway/Services/Routing/ApiSender.cs
@@ -34,7 +34,8 @@ public class ApiSender(IHttpClientFactory clientFactory, IServiceProvider servic
 {
     public async Task<RoutingResult> Send(RoutingResult routingResult, MessageData messageData, bool fork)
     {
-        var client = clientFactory.CreateClient(fork ? Proxy.ForkedClientWithRetry : Proxy.RoutedClientWithRetry);
+        var proxyName = routingResult.NamedProxy ?? (fork ? Proxy.ForkedClientWithRetry : Proxy.RoutedClientWithRetry);
+        var client = clientFactory.CreateClient(proxyName);
 
         HttpRequestMessage request;
 

--- a/BtmsGateway/Services/Routing/MessageRoutes.cs
+++ b/BtmsGateway/Services/Routing/MessageRoutes.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
-using BtmsGateway.Domain;
 using BtmsGateway.Exceptions;
 using BtmsGateway.Services.Converter;
 using ILogger = Serilog.ILogger;
@@ -105,6 +104,7 @@ public class MessageRoutes : IMessageRoutes
                 ConvertForkedContentToFromJson = true,
                 UrlPath = routePath,
                 StatusCode = route.LegacyLinkType == LinkType.None ? HttpStatusCode.Accepted : default,
+                NamedProxy = route.NamedProxy,
             },
             RouteTo.Btms => new RoutingResult
             {
@@ -121,6 +121,7 @@ public class MessageRoutes : IMessageRoutes
                 ConvertRoutedContentToFromJson = true,
                 UrlPath = routePath,
                 StatusCode = route.BtmsLinkType == LinkType.None ? HttpStatusCode.Accepted : default,
+                NamedProxy = route.NamedProxy,
             },
             _ => throw new ArgumentOutOfRangeException(
                 nameof(route),

--- a/BtmsGateway/Services/Routing/RoutingConfig.cs
+++ b/BtmsGateway/Services/Routing/RoutingConfig.cs
@@ -24,6 +24,7 @@ public record RoutingConfig
                     nr.Value.Legend,
                     nr.Value.RouteTo,
                     nr.Value.IsCds,
+                    nr.Value.NamedProxy,
                 }
         );
         var btms = NamedRoutes.Join(
@@ -42,6 +43,7 @@ public record RoutingConfig
                     nr.Value.Legend,
                     nr.Value.RouteTo,
                     nr.Value.IsCds,
+                    nr.Value.NamedProxy,
                 }
         );
         var output = legacy
@@ -64,6 +66,7 @@ public record RoutingConfig
                         MessageSubXPath = l.MessageSubXPath,
                         RouteTo = b.RouteTo,
                         IsCds = b.IsCds,
+                        NamedProxy = b.NamedProxy,
                     }
             )
             .ToArray();
@@ -85,6 +88,7 @@ public record NamedRoute
     public string? BtmsLinkName { get; init; }
     public required RouteTo RouteTo { get; init; }
     public bool IsCds { get; init; }
+    public string? NamedProxy { get; init; }
 }
 
 public record NamedLink
@@ -128,6 +132,7 @@ public record RoutedLink
     public string? BtmsHostHeader { get; init; }
     public required RouteTo RouteTo { get; init; }
     public required bool IsCds { get; init; }
+    public string? NamedProxy { get; init; }
 }
 
 public enum RouteTo

--- a/BtmsGateway/Services/Routing/RoutingResult.cs
+++ b/BtmsGateway/Services/Routing/RoutingResult.cs
@@ -24,4 +24,5 @@ public record RoutingResult
     public DateTimeOffset? ResponseDate { get; init; }
     public HttpStatusCode StatusCode { get; init; }
     public string? ErrorMessage { get; init; }
+    public string? NamedProxy { get; init; }
 }

--- a/BtmsGateway/Utils/Http/Proxy.cs
+++ b/BtmsGateway/Utils/Http/Proxy.cs
@@ -17,12 +17,14 @@ public static class Proxy
 {
     public static readonly int DefaultHttpClientTimeoutSeconds = 10;
     public static readonly int DefaultCdsHttpClientRetries = 3;
+    public static readonly int DefaultAlvsIpaffsHttpClientTimeoutSeconds = 100;
 
     public const string ProxyClientWithoutRetry = "proxy";
     public const string CdsProxyClientWithRetry = "proxy-with-retry";
     public const string RoutedClientWithRetry = "routed-with-retry";
     public const string ForkedClientWithRetry = "forked-with-retry";
     public const string DecisionComparerProxyClientWithRetry = "decision-comparer-proxy-with-retry";
+    public const string AlvsIpaffsProxyClientWithRetry = "alvs-ipaffs-proxy-with-retry";
 
     [ExcludeFromCodeCoverage]
     public static IHttpClientBuilder AddHttpProxyClientWithoutRetry(this IServiceCollection services)
@@ -41,7 +43,8 @@ public static class Proxy
     [ExcludeFromCodeCoverage]
     public static IHttpClientBuilder AddHttpProxyRoutedClientWithRetry(
         this IServiceCollection services,
-        int httpClientTimeoutInSeconds
+        int httpClientTimeoutInSeconds,
+        string namedProxy = RoutedClientWithRetry
     )
     {
         var strategy = Policy.WrapAsync(
@@ -50,7 +53,7 @@ public static class Proxy
         );
 
         return services
-            .AddHttpClient(RoutedClientWithRetry)
+            .AddHttpClient(namedProxy)
             .ConfigurePrimaryHttpMessageHandler(ConfigurePrimaryHttpMessageHandler)
             .AddPolicyHandler(strategy);
     }

--- a/BtmsGateway/appsettings.IntegrationTests.json
+++ b/BtmsGateway/appsettings.IntegrationTests.json
@@ -36,5 +36,6 @@
     "TrialCutover": false,
     "Cutover": false
   },
-  "HttpClientTimeoutSeconds": 1
+  "HttpClientTimeoutSeconds": 1,
+  "AlvsIpaffsHttpClientTimeoutSeconds": 1
 }

--- a/BtmsGateway/appsettings.json
+++ b/BtmsGateway/appsettings.json
@@ -100,7 +100,8 @@
         "LegacyLinkName": "Stub",
         "BtmsLinkName": "None",
         "MessageBodyDepth": 2,
-        "RouteTo": "Legacy"
+        "RouteTo": "Legacy",
+        "NamedProxy": "alvs-ipaffs-proxy-with-retry"
       },
       "ALVSPollSearchCertificateResultToIpaffs": {
         "RoutePath": "/soapsearch/tst/sanco/traces_ws/pollSearchCertificateResult",
@@ -109,7 +110,8 @@
         "LegacyLinkName": "Stub",
         "BtmsLinkName": "None",
         "MessageBodyDepth": 2,
-        "RouteTo": "Legacy"
+        "RouteTo": "Legacy",
+        "NamedProxy": "alvs-ipaffs-proxy-with-retry"
       },
       "ALVSDecisionNotificationToIpaffs": {
         "RoutePath": "/soapsearch/tst/sanco/traces_ws/sendALVSDecisionNotification",

--- a/tests/BtmsGateway.IntegrationTests/BtmsGateway.IntegrationTests.csproj
+++ b/tests/BtmsGateway.IntegrationTests/BtmsGateway.IntegrationTests.csproj
@@ -27,6 +27,9 @@
     <None Update="Fixtures\DecisionNotification.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Fixtures\SearchCertificate.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="TestBase\" />

--- a/tests/BtmsGateway.IntegrationTests/Fixtures/SearchCertificate.xml
+++ b/tests/BtmsGateway.IntegrationTests/Fixtures/SearchCertificate.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<NS1:Envelope xmlns:NS1="http://www.w3.org/2003/05/soap-envelope">
+  <NS1:Header/>
+  <NS1:Body>
+    <NS2:CertificateRequest xmlns:NS2="traceswsns">
+      <NS2:XMLSchemaVersion>2.0</NS2:XMLSchemaVersion>
+      <NS2:UserIdentification>username</NS2:UserIdentification>
+      <NS2:UserPassword>password</NS2:UserPassword>
+      <NS2:SendingDate>2025-03-27 11:07</NS2:SendingDate>
+      <NS2:Request>
+        <NS2:SearchCriterionCVEDAnimal>
+          <NS2:ModifiedBetween>
+            <NS2:StartDate>2025-03-27 11:06</NS2:StartDate>
+            <NS2:EndDate>2025-03-27 12:06</NS2:EndDate>
+          </NS2:ModifiedBetween>
+          <NS2:CountryOfDestination>GB</NS2:CountryOfDestination>
+          <NS2:FetchAmount>100</NS2:FetchAmount>
+        </NS2:SearchCriterionCVEDAnimal>
+      </NS2:Request>
+    </NS2:CertificateRequest>
+  </NS1:Body>
+</NS1:Envelope>

--- a/tests/BtmsGateway.IntegrationTests/Utils/Http/ProxyTests.cs
+++ b/tests/BtmsGateway.IntegrationTests/Utils/Http/ProxyTests.cs
@@ -60,4 +60,44 @@ public class ProxyTests(WireMockClient wireMockClient)
 
         response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
     }
+
+    [Fact]
+    public async Task When_post_to_ipaffs_takes_longer_than_http_client_timeout_Then_service_unavailable_returned()
+    {
+        var fixtureContent = FixtureTest.UsingContent("SearchCertificate.xml");
+
+        await using var application = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("IntegrationTests");
+        });
+
+        var configuration = application.Services.GetService(typeof(IConfiguration));
+        var httpClientTimeoutSeconds = ((ConfigurationManager)configuration!).GetValue<int>(
+            "AlvsIpaffsHttpClientTimeoutSeconds"
+        );
+
+        var responseDelay =
+            httpClientTimeoutSeconds > 0
+                ? httpClientTimeoutSeconds + 1
+                : Proxy.DefaultAlvsIpaffsHttpClientTimeoutSeconds + 1;
+
+        var postMappingBuilder = _wireMockAdminApi.GetMappingBuilder();
+        postMappingBuilder.Given(m =>
+            m.WithRequest(req => req.UsingPost().WithPath("/soapsearch/tst/sanco/traces_ws/searchCertificate"))
+                .WithResponse(rsp =>
+                    rsp.WithStatusCode(HttpStatusCode.ServiceUnavailable).WithDelay(TimeSpan.FromSeconds(responseDelay))
+                )
+        );
+        var postStatus = await postMappingBuilder.BuildAndPostAsync();
+        Assert.NotNull(postStatus.Guid);
+
+        using var client = application.CreateClient();
+
+        var response = await client.PostAsync(
+            "/soapsearch/tst/sanco/traces_ws/searchCertificate",
+            new StringContent(fixtureContent)
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
 }


### PR DESCRIPTION
- Allows for configuration of routes to use a specific named HTTP Client
- Provides a named HTTP Client specifically for ALVS to IPAFFS Search and Poll Search requests
- This client is configured with longer request timeout (defaulted to 100 seconds which was used before Cutover)