### PR TITLE
CDMS-1143: Truncate decision reason if greater than 512 in length

### DIFF
--- a/BtmsGateway/Services/Converter/ClearanceDecisionToSoapConverter.cs
+++ b/BtmsGateway/Services/Converter/ClearanceDecisionToSoapConverter.cs
@@ -74,9 +74,17 @@ public static class ClearanceDecisionToSoapConverter
         foreach (var checkDecisionReason in check.DecisionReasons)
         {
             if (!string.IsNullOrEmpty(checkDecisionReason))
-                checkElement.Add(new XElement("DecisionReason", checkDecisionReason));
+                checkElement.Add(new XElement("DecisionReason", EnsureMaxLength(checkDecisionReason, 512)));
         }
 
         return checkElement;
+    }
+
+    private static string EnsureMaxLength(string value, int maxLength)
+    {
+        if (value.Length <= maxLength)
+            return value;
+
+        return value[..509] + "...";
     }
 }

--- a/tests/BtmsGateway.Test/Services/Converter/ClearanceDecisionToSoapConverterTests.cs
+++ b/tests/BtmsGateway.Test/Services/Converter/ClearanceDecisionToSoapConverterTests.cs
@@ -6,7 +6,7 @@ namespace BtmsGateway.Test.Services.Converter;
 
 public class ClearanceDecisionToSoapConverterTests
 {
-    private static readonly string TestDataPath = Path.Combine(
+    private static readonly string s_testDataPath = Path.Combine(
         AppDomain.CurrentDomain.BaseDirectory,
         "Services",
         "Converter",
@@ -16,7 +16,7 @@ public class ClearanceDecisionToSoapConverterTests
     [Fact]
     public void When_receiving_clearance_decision_Then_should_convert_to_soap()
     {
-        var expectedSoap = File.ReadAllText(Path.Combine(TestDataPath, "DecisionNotificationWithHtmlEncoding.xml"));
+        var expectedSoap = File.ReadAllText(Path.Combine(s_testDataPath, "DecisionNotificationWithHtmlEncoding.xml"));
 
         var clearanceDecision = new ClearanceDecision
         {

--- a/tests/BtmsGateway.Test/Services/Converter/ClearanceDecisionToSoapConverterTests.cs
+++ b/tests/BtmsGateway.Test/Services/Converter/ClearanceDecisionToSoapConverterTests.cs
@@ -43,4 +43,83 @@ public class ClearanceDecisionToSoapConverterTests
 
         result.Should().Be(expectedSoap);
     }
+
+    [Fact]
+    public void When_adding_reason_of_max_length_Then_should_maintain_length()
+    {
+        var decisionReason = StringOfLength(512);
+        var clearanceDecision = new ClearanceDecision
+        {
+            CorrelationId = "000",
+            Created = DateTime.Parse("2025-05-29T18:57:29.298"),
+            ExternalVersionNumber = 3,
+            DecisionNumber = 3,
+            Items =
+            [
+                new ClearanceDecisionItem
+                {
+                    ItemNumber = 1,
+                    Checks =
+                    [
+                        new ClearanceDecisionCheck
+                        {
+                            CheckCode = "H219",
+                            DecisionCode = "H02",
+                            DecisionReasons = [decisionReason],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var result = ClearanceDecisionToSoapConverter.Convert(
+            clearanceDecision,
+            "25GB1HG99NHUJO3999",
+            "test-username",
+            "test-password"
+        );
+
+        result.Should().Contain(decisionReason);
+    }
+
+    [Theory]
+    [InlineData(513)]
+    [InlineData(600)]
+    public void When_adding_reason_of_greater_than_max_length_Then_should_truncate(int length)
+    {
+        var clearanceDecision = new ClearanceDecision
+        {
+            CorrelationId = "000",
+            Created = DateTime.Parse("2025-05-29T18:57:29.298"),
+            ExternalVersionNumber = 3,
+            DecisionNumber = 3,
+            Items =
+            [
+                new ClearanceDecisionItem
+                {
+                    ItemNumber = 1,
+                    Checks =
+                    [
+                        new ClearanceDecisionCheck
+                        {
+                            CheckCode = "H219",
+                            DecisionCode = "H02",
+                            DecisionReasons = [StringOfLength(length)],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var result = ClearanceDecisionToSoapConverter.Convert(
+            clearanceDecision,
+            "25GB1HG99NHUJO3999",
+            "test-username",
+            "test-password"
+        );
+
+        result.Should().Contain(StringOfLength(length)[..509] + "...");
+    }
+
+    private static string StringOfLength(int length) => new('a', length);
 }


### PR DESCRIPTION
As per PR title.

CDS has a limit of 512 characters for decision reasons.

BTMS may produce longer, therefore we truncate before sending yet we preserve the full reason we generated within BTMS.