### PR TITLE
CDMS-1433: Pin GitHub Actions to specific commit SHAs

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -36,7 +36,7 @@ jobs:
           dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --configfile ./NuGet.config
 #      Remove this running of docker compose once E2E tests have been updated and/or moved to the IntegrationTests project
       - name: Run docker-compose
-        uses: hoverkraft-tech/compose-action@2559440fcbf894fcfb27d2c05b8c38e9148a3d6f
+        uses: hoverkraft-tech/compose-action@d2bee4f07e8ca410d6b196d00f90c12e7d48c33a
         with:
           compose-file: "./compose.yml"
       - name: Test

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:   
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483 #v6
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
         with:
           dotnet-version: |
             10.0
@@ -36,7 +36,7 @@ jobs:
           dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --configfile ./NuGet.config
 #      Remove this running of docker compose once E2E tests have been updated and/or moved to the IntegrationTests project
       - name: Run docker-compose
-        uses: hoverkraft-tech/compose-action@v2.6.0
+        uses: hoverkraft-tech/compose-action@2559440fcbf894fcfb27d2c05b8c38e9148a3d6f
         with:
           compose-file: "./compose.yml"
       - name: Test

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:   
       - name: Check out code
-        uses: actions/checkout@8e8c483 #v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6
       - name: Setup dotnet
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
         with:

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@8e8c483 #v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6
         with:
           fetch-depth: 0 # Depth 0 required for branch-based versioning
       - name: Update NuGet.config

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -28,7 +28,7 @@ jobs:
           dotnet nuget remove source defra --configfile ./NuGet.config
           dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --configfile ./NuGet.config
       - name: Publish Hot Fix
-        uses: DEFRA/cdp-build-action/build-hotfix@main
+        uses: DEFRA/cdp-build-action/build-hotfix@dfb7dbaa4129b6e7e6b250c043d06628b32f8167
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
     ## SonarCloud

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483 #v6
         with:
           fetch-depth: 0 # Depth 0 required for branch-based versioning
       - name: Update NuGet.config

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483 #v6
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
         with:
           dotnet-version: |
             10.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
           dotnet nuget remove source defra
           dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name defra "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --configfile NuGet.config
       - name: Build and Publish
-        uses: DEFRA/cdp-build-action/build@main
+        uses: DEFRA/cdp-build-action/build@5f3ba75f66a3ef96855322c137727ff996cc2995
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   sonarcloud-scan:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@8e8c483 #v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6
       - name: Setup dotnet
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
         with:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -20,7 +20,7 @@ jobs:
           java-version: 17
           distribution: "zulu"
       - name: Check out code
-        uses: actions/checkout@8e8c483 #v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #v6
         with:
           fetch-depth: 0
       - name: Set up .NET 10.0

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -59,7 +59,7 @@ jobs:
           mkdir -p ./.sonar/coverage
           dotnet tool update dotnet-coverage --tool-path ./.sonar/coverage
       - name: Run docker-compose # Runs the existing Docker compose and scripts for now until the tests can be rewritten
-        uses: hoverkraft-tech/compose-action@2559440fcbf894fcfb27d2c05b8c38e9148a3d6f
+        uses: hoverkraft-tech/compose-action@d2bee4f07e8ca410d6b196d00f90c12e7d48c33a
         with:
           compose-file: "./compose.yml"
         env:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -15,35 +15,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           java-version: 17
           distribution: "zulu"
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483 #v6
         with:
           fetch-depth: 0
       - name: Set up .NET 10.0
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 #v5
         with:
           dotnet-version: |
             10.0
       - name: Cache SonarCloud packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5
         with:
           path: ~/sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache SonarCloud scanner
         id: cache-sonar-scanner
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5
         with:
           path: ./.sonar/scanner
           key: ${{ runner.os }}-sonar-scanner
           restore-keys: ${{ runner.os }}-sonar-scanner
       - name: Cache dotNet code coverage
         id: cache-sonar-coverage
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5
         with:
           path: ./.sonar/coverage
           key: ${{ runner.os }}-sonar-coverage
@@ -59,7 +59,7 @@ jobs:
           mkdir -p ./.sonar/coverage
           dotnet tool update dotnet-coverage --tool-path ./.sonar/coverage
       - name: Run docker-compose # Runs the existing Docker compose and scripts for now until the tests can be rewritten
-        uses: hoverkraft-tech/compose-action@v2.6.0
+        uses: hoverkraft-tech/compose-action@2559440fcbf894fcfb27d2c05b8c38e9148a3d6f
         with:
           compose-file: "./compose.yml"
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ EXPOSE 443
 # Add curl to template.
 # CDP PLATFORM HEALTHCHECK REQUIREMENT
 RUN apt update && \
+    apt upgrade -y && \
     apt install curl -y && \
     apt install dnsutils -y && \
     apt install iputils-ping -y && \


### PR DESCRIPTION
Updates workflow files to use immutable commit SHAs for actions instead of mutable version tags. This enhances build stability and reproducibility by preventing unexpected changes from upstream action updates.
