### PR TITLE
CDMS-1478 - Update Data API client

### DIFF
--- a/BtmsGateway/BtmsGateway.csproj
+++ b/BtmsGateway/BtmsGateway.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Amazon.CloudWatch.EMF" Version="2.2.0" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.22" />
     <PackageReference Include="Defra.TradeImports.SMB.CompressedSerializer" Version="0.2.0" />
-    <PackageReference Include="Defra.TradeImportsDataApi.Domain" Version="0.35.0" />
+    <PackageReference Include="Defra.TradeImportsDataApi.Domain" Version="0.36.0-pr-546.2380" />
     <PackageReference Include="Defra.TradeImports.SQS.Endpoints" Version="0.1.2" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="9.0.0" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="9.0.0" />


### PR DESCRIPTION
Updates the `Defra.TradeImportsDataApi.Api.Client` package to version `0.41.0-pr-546.2380`. This pre-release version includes the necessary changes to support the `CDMS-1478` feature.
